### PR TITLE
Legger til prettier for automatisk formatering av typescript kode

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    trailingComma: "es5",
+    tabWidth: 4,
+    semi: true,
+    singleQuote: false,
+    bracketSpacing: false,
+  };

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@types/react": "16.8.8",
     "@types/react-dom": "16.8.2",
+    "prettier": "1.19.1",
     "typescript": "3.3.3"
   },
   "scripts": {


### PR DESCRIPTION
Legger til støtte for å kunne bruke prettier for automatisk formatering av kode. Dette sikrer at vi får samme kodestil uavhengig av oppsett / editor. Det er også mulig å legge inn commit-hook hvis det er ønskelig.