### PR TITLE
Bytter ut normaltekst med nytt komponent for avsnitt som har riktig stilsetting fremfor bruk av <br/> tagger

### DIFF
--- a/src/artikler/behandlingstid/BehandlingstidBokmal.tsx
+++ b/src/artikler/behandlingstid/BehandlingstidBokmal.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 import Artikkel from "../Artikkel";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 import "../artikkel.less";
 
 const BehandlingstidBokmal: React.FC = () => {
@@ -10,7 +11,7 @@ const BehandlingstidBokmal: React.FC = () => {
             <Innholdstittel>
                 Hvor lang tid tar det å behandle søknaden?
             </Innholdstittel>
-            <Normaltekst>
+            <Avsnitt>
                 Saksbehandlingstiden varierer fra kommune til kommune. Hvis det
                 går mer enn én måned, skal du få brev om forlenget
                 saksbehandlingstid. Hvis vi mangler opplysninger, vil du få
@@ -19,7 +20,7 @@ const BehandlingstidBokmal: React.FC = () => {
                 for å få raskest mulig svar på søknaden din. Hvis du er i en{" "}
                 <Lenke href={"./nodsituasjon?lang=nb"}>nødsituasjon</Lenke>,
                 skal du få et raskt svar.
-            </Normaltekst>
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/dette-bor-du-vite/DetteBorDuViteBokmal.tsx
+++ b/src/artikler/dette-bor-du-vite/DetteBorDuViteBokmal.tsx
@@ -1,15 +1,11 @@
 import * as React from "react";
 import Artikkel from "../Artikkel";
-import {
-    Ingress,
-    Innholdstittel,
-    Normaltekst,
-    Undertittel,
-} from "nav-frontend-typografi";
+import {Ingress, Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import Lenke from "nav-frontend-lenker";
 
 import IllustrasjonInfoSirkel from "../../komponenter/bilder/IllustrasjonInfoSirkel";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const DetteBorDuViteBokmal: React.FC = () => {
     return (
@@ -35,17 +31,17 @@ const DetteBorDuViteBokmal: React.FC = () => {
             </Ingress>
 
             <Undertittel>Før du søker</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 Når du søker må du gi opplysninger om deg selv og den økonomiske
                 situasjonen din. Du må i utgangspunktet dokumentere
                 opplysningene.
-            </Normaltekst>
+            </Avsnitt>
 
             <Ekspanderbartpanel
                 tittel="Eksempler på hva du kan bli bedt om å dokumentere"
                 border
             >
-                <Normaltekst>
+                <div className="typo-normal">
                     <ul>
                         <li>legitimasjon</li>
                         <li>gyldig oppholdstillatelse</li>
@@ -71,76 +67,79 @@ const DetteBorDuViteBokmal: React.FC = () => {
                             tannbehandling
                         </li>
                     </ul>
-                </Normaltekst>
+                </div>
             </Ekspanderbartpanel>
 
-            <br />
-            <Normaltekst>
+            <Avsnitt>
                 Du må i utgangspunktet ha lovlig opphold i Norge for å ha rett
                 til økonomisk sosialhjelp. Du har ikke rett til økonomisk
                 sosialhjelp hvis du oppholder deg i utlandet.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Alle har rett til å søke om økonomisk sosialhjelp og få en
                 individuell vurdering av søknaden sin. Du har rett til{" "}
                 <Lenke href="https://www.nav.no/no/person/flere-tema/sosiale-tjenester/generelle-rad-og-veiledning">
                     opplysning, råd og veiledning
                 </Lenke>{" "}
                 uavhengig av om du har rett til økonomisk sosialhjelp.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Etter du har søkt</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 Saksbehandlingstiden varierer fra kommune til kommune. Hvis det
                 går mer enn én måned, skal du få et foreløpig svar. Hvis du ikke
                 har levert all nødvendig dokumentasjon, kan det ta lengre tid
                 før du får svar på søknaden din. Hvis du er i en{" "}
                 <Lenke href="./nodsituasjon">nødssituasjon</Lenke>, skal du få
                 et raskt svar.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Du må <Lenke href="./gi-beskjed">gi beskjed</Lenke> til oss hvis
                 situasjonen din endrer seg etter at du har søkt.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Når vi har behandlet søknaden din, får du et vedtak som du må
                 lese nøye. Ofte vil vi stille ett eller flere{" "}
                 <Lenke href="./krav-til-deg">krav til deg</Lenke> i vedtaket som
                 du må oppfylle.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Du kan <Lenke href="./klage">klage</Lenke> hvis du mener at
                 vedtaket er feil. Klagefrist er 3 uker fra du mottar vedtaket.
-            </Normaltekst>
+            </Avsnitt>
+
             <Undertittel>Satser</Undertittel>
-            <Normaltekst>
+
+            <Avsnitt>
                 Stønaden blir beregnet etter en individuell vurdering.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Det finnes{" "}
                 <Lenke href="https://www.nav.no/no/nav-og-samfunn/kontakt-nav/oversikt-over-satser/statlige-veiledende-retningslinjer-for-okonomisk-stonad_kap">
                     statlige veiledende satser og retningslinjer
                 </Lenke>{" "}
                 for å beregne økonomisk stønad. Kommunen din kan ha egne
                 veiledende satser.
-            </Normaltekst>
+            </Avsnitt>
+
             <Undertittel>Utbetalinger</Undertittel>
-            <Normaltekst>
+
+            <Avsnitt>
                 I vedtaksbrevet ditt finner du mer informasjon om utbetalinger.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Se utfyllende informasjon om{" "}
                 <Lenke href="https://www.nav.no/no/person/flere-tema/sosiale-tjenester/okonomisk-sosialhjelp2">
                     økonomisk sosialhjelp
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/dette-bor-du-vite/DetteBorDuViteEnglish.tsx
+++ b/src/artikler/dette-bor-du-vite/DetteBorDuViteEnglish.tsx
@@ -1,14 +1,10 @@
 import * as React from "react";
 import Artikkel from "../Artikkel";
-import {
-    Ingress,
-    Innholdstittel,
-    Normaltekst,
-    Undertittel,
-} from "nav-frontend-typografi";
+import {Ingress, Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import IllustrasjonInfoSirkel from "../../komponenter/bilder/IllustrasjonInfoSirkel";
 import Lenke from "nav-frontend-lenker";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const DetteBorDuViteEnglish: React.FC = () => {
     return (
@@ -34,17 +30,17 @@ const DetteBorDuViteEnglish: React.FC = () => {
             </Ingress>
 
             <Undertittel>Before you apply</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 When you apply, you must provide information about yourself and
                 your financial situation. You usually have to provide
                 documentation for this information.
-            </Normaltekst>
+            </Avsnitt>
 
             <Ekspanderbartpanel
                 tittel="Examples of documentation you must include in your application"
                 border
             >
-                <Normaltekst>
+                <div className="typo-normal">
                     <ul>
                         <li>Identification</li>
                         <li>Valid residence permit</li>
@@ -73,17 +69,16 @@ const DetteBorDuViteEnglish: React.FC = () => {
                             and/or dental services
                         </li>
                     </ul>
-                </Normaltekst>
+                </div>
             </Ekspanderbartpanel>
 
-            <br />
-            <Normaltekst>
+            <Avsnitt>
                 Before you apply for financial aid, you should usually have a
                 legal residence i Norway. If you live abroad you do not qualify
                 for social assistance.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Everyone has the right to submit an application for financial
                 assistance and to have NAV conduct an individual assessment of
                 their application. You have the rights to{" "}
@@ -91,10 +86,10 @@ const DetteBorDuViteEnglish: React.FC = () => {
                     information, advice and guidance
                 </Lenke>
                 , regardless of your current financial situation.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>After you apply</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 Processing times vary from municipality to municipality. If more
                 than a month goes by, you are entitled to a preliminary
                 response. If you fail to submit all the necessary documentation,
@@ -103,14 +98,14 @@ const DetteBorDuViteEnglish: React.FC = () => {
                     situation is an emergency
                 </Lenke>
                 , you are entitled to get a response quickly.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 You must <Lenke href="./gi-beskjed?lang=en">notify</Lenke> us of
                 any changes to your situation.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Once we have processed your application, we will make a
                 decision, and you must read the decision carefully. Often, there
                 will be one or more{" "}
@@ -118,40 +113,43 @@ const DetteBorDuViteEnglish: React.FC = () => {
                     conditions listed in the decision
                 </Lenke>{" "}
                 that you have to meet.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 If you believe the decision is wrong, you have the right to{" "}
                 <Lenke href="./klage?lang=en">appeal</Lenke>. The term of appeal
                 is 3 weeks from the date on which you receive notice of the
                 decision.
-            </Normaltekst>
+            </Avsnitt>
+
             <Undertittel>Rates</Undertittel>
-            <Normaltekst>
+
+            <Avsnitt>
                 Financial assistance is granted on the basis of an individual
                 assessment.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 There are, however,{" "}
                 <Lenke href="https://www.nav.no/no/nav-og-samfunn/kontakt-nav/oversikt-over-satser/statlige-veiledende-retningslinjer-for-okonomisk-stonad_kap">
                     standard government rates and guidelines
                 </Lenke>{" "}
                 for calculating social assistance. Your municipality may apply
                 its own standard rates.
-            </Normaltekst>
+            </Avsnitt>
+
             <Undertittel>Payments</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 Your decision notice will include information about payments.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Read more about{" "}
                 <Lenke href="https://www.nav.no/en/Home/Benefits+and+services/Relatert+informasjon/financial-assistance-social-assistance">
                     financial assistance
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/dette-bor-du-vite/DetteBorDuViteNynorsk.tsx
+++ b/src/artikler/dette-bor-du-vite/DetteBorDuViteNynorsk.tsx
@@ -1,14 +1,10 @@
 import * as React from "react";
 import Artikkel from "../Artikkel";
-import {
-    Ingress,
-    Innholdstittel,
-    Normaltekst,
-    Undertittel,
-} from "nav-frontend-typografi";
+import {Ingress, Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import IllustrasjonInfoSirkel from "../../komponenter/bilder/IllustrasjonInfoSirkel";
 import Lenke from "nav-frontend-lenker";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const DetteBorDuViteNynorsk: React.FC = () => {
     return (
@@ -34,16 +30,16 @@ const DetteBorDuViteNynorsk: React.FC = () => {
             </Ingress>
 
             <Undertittel>Før du søkjer</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 Når du søkjer må du gi opplysningar om deg sjølv og situasjonen
                 din. Du må i utgangspunktet dokumentere opplysningane.
-            </Normaltekst>
+            </Avsnitt>
 
             <Ekspanderbartpanel
                 tittel="Døme på kva du må leggje ved søknaden"
                 border
             >
-                <Normaltekst>
+                <div className="typo-normal">
                     <ul>
                         <li>legitimasjon</li>
                         <li>gyldig opphaldsløyve</li>
@@ -69,77 +65,78 @@ const DetteBorDuViteNynorsk: React.FC = () => {
                             tannbehandling
                         </li>
                     </ul>
-                </Normaltekst>
+                </div>
             </Ekspanderbartpanel>
 
-            <br />
-            <Normaltekst>
+            <Avsnitt>
                 Du må i utgangspunktet ha lovleg opphald i Noreg for å ha rett
                 til økonomisk sosialhjelp. Du har ikkje rett til økonomisk
                 sosialhjelp dersom du oppheld deg i utlandet.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Alle har rett til å søkje om økonomisk sosialhjelp, og få ei
                 individuell vurdering av søknaden sin. Du har rett til{" "}
                 <Lenke href="https://www.nav.no/no/person/flere-tema/sosiale-tjenester/nynorsk/generelle-rad-og-rettleiing">
                     opplysning, råd og rettleiing
                 </Lenke>{" "}
                 uavhengig av om du har rett til økonomisk sosialhjelp.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Etter du har søkt</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 Saksbehandlingstida varierer frå kommune til kommune. Dersom det
                 går meir enn éin månad, skal du få eit førebels svar. Om du
                 ikkje har levert all nødvendig dokumentasjon, kan det ta lengre
                 tid før du får svar på søknaden din. Om du er i en{" "}
                 <Lenke href="./nodsituasjon?lang=nn">nødssituasjon</Lenke>, skal
                 du få svaret raskt.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Du må <Lenke href="./gi-beskjed?lang=nn">melde frå</Lenke> til
                 oss dersom det skjer endringar i situasjonen din.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Når vi har behandla søknaden din, får du eit vedtak som du må
                 lese nøye. Ofte vil vi stille eitt eller fleire{" "}
                 <Lenke href="./krav-til-deg?lang=nn">krav til deg</Lenke> i
                 vedtaket som du må oppfylle.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Du kan <Lenke href="./klage?lang=nn">klage</Lenke> hvis du
                 meiner at vedtaket er feil. Klagefrist er 3 uker frå du har fått
                 vedtaket.
-            </Normaltekst>
+            </Avsnitt>
+
             <Undertittel>Satsar</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 Stønaden blir utrekna etter ei individuell vurdering.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Det finst{" "}
                 <Lenke href="https://www.nav.no/no/nav-og-samfunn/kontakt-nav/oversikt-over-satser/statlige-veiledende-retningslinjer-for-okonomisk-stonad_kap">
                     statlege rettleiande satsar og retningslinjer
                 </Lenke>{" "}
                 for å utrekne økonomisk stønad. Kommunen din kan ha eigne
                 rettleiande satsar.
-            </Normaltekst>
+            </Avsnitt>
+
             <Undertittel>Utbetalingar</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 I vedtaksbrevet ditt finn du meir informasjon om utbetalingar.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Sjå utfyllande informasjon om{" "}
                 <Lenke href="https://www.nav.no/no/Person/Flere+tema/Sosiale+tjenester/Nynorsk/%C3%B8konomisk-sosialhjelp">
                     økonomisk sosialhjelp
                 </Lenke>
                 .{" "}
-            </Normaltekst>
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/dette-kan-du-soke-om/DetteKanDuSokeOmBokmal.tsx
+++ b/src/artikler/dette-kan-du-soke-om/DetteKanDuSokeOmBokmal.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import Lenke from "nav-frontend-lenker";
 import Artikkel from "../Artikkel";
 import IllustrasjonBygningPerson from "../../komponenter/bilder/IllustrasjonBygningPerson";
 import "../artikkel.less";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const DetteKanDuSokeOmBokmal: React.FC = () => {
     return (
@@ -15,86 +16,81 @@ const DetteKanDuSokeOmBokmal: React.FC = () => {
             }
         >
             <Innholdstittel>Dette kan du søke om</Innholdstittel>
-            <Normaltekst>
-                Vi vurderer behovet ditt for økonomisk sosialhjelp sammen med deg
-                og gjør en individuell vurdering. Hvor mye du kan få utbetalt er
-                avhengig av din familiesituasjon, antall personer som hører til
-                husholdningen, bosituasjonen med mer.
-            </Normaltekst>
+            <Avsnitt>
+                Vi vurderer behovet ditt for økonomisk sosialhjelp sammen med
+                deg og gjør en individuell vurdering. Hvor mye du kan få
+                utbetalt er avhengig av din familiesituasjon, antall personer
+                som hører til husholdningen, bosituasjonen med mer.
+            </Avsnitt>
 
             <Undertittel>Utgifter du kan søke om å få hjelp med</Undertittel>
 
-            <Normaltekst>
-                Du kan søke om å få hjelp med utgifter til
-            </Normaltekst>
+            <Avsnitt>Du kan søke om å få hjelp med utgifter til</Avsnitt>
 
             <Ekspanderbartpanel tittel="å leve" border>
-                <Normaltekst>
+                <Avsnitt>
                     De helt grunnleggende behovene som mat, klær, bolig og
                     oppvarming omtaler vi ofte som livsopphold når vi gjør et
                     vedtak om sosialhjelp.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Også utgifter til fritidsaktiviteter, telefoni, tv,
                     internett, transport og helse- og tannbehandling regner NAV
                     som en del av livsoppholdet. Vi ser også på om du har
                     særlige ekstrautgifter som vi bør ta hensyn til. Vi legger
                     særlig vekt på barn og unges behov.
-                </Normaltekst>
+                </Avsnitt>
             </Ekspanderbartpanel>
 
             <Ekspanderbartpanel tittel="å bo" border>
                 <Undertittel tag="h3">Boutgifter og strømutgifter</Undertittel>
-                <br />
-                <Normaltekst>
+                <Avsnitt>
                     Du kan søke om å få dekket løpende utgifter til bolig, som
                     husleie, kommunale avgifter, faste utgifter i borettslag,
                     sameie og lignende, og betaling av renter på boliglån. Har
                     du boliglån vil vi be deg søke banken om en periode der du
                     ikke betaler avdrag.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Du kan også søke om å få dekket løpende utgifter til strøm
                     og oppvarming.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Hvis boutgiftene dine er så høye at du ikke er i stand til å
                     betjene dem med de inntektene du har eller kan forvente å
                     få, kan vi stille krav om at du må redusere boutgiftene
                     dine. Det kan bety at du må flytte til en rimeligere bolig.
                     I slike situasjoner er det viktig å ta hensyn til det
                     behovet barn og unge har for å holde på nettverket sitt.
-                </Normaltekst>
-                <br />
+                </Avsnitt>
+
                 <Undertittel tag="h3">Flytting</Undertittel>
-                <br />
-                <Normaltekst>
+                <Avsnitt>
                     NAV kan vurdere å gi stønad til nødvendige utgifter til
                     flytting. Særlig aktuelt er dette hvis det er NAV-kontoret
                     som har pålagt deg å flytte for å redusere boutgiftene,
                     eller hvis det er andre særskilte grunner til at du må
                     flytte.
-                </Normaltekst>
-                <br />
+                </Avsnitt>
+
                 <Undertittel tag="h3">Innbo og utstyr</Undertittel>
-                <br />
-                <Normaltekst>
+
+                <Avsnitt>
                     Du kan søke om stønad til det mest nødvendige av innbo og
                     utstyr til å bo i en bolig, hvis du ikke har økonomi til å
                     skaffe dette på andre måter. NAV vurderer hva som er
                     nødvendig utstyr ut fra individuelle behov, livssituasjon,
                     alder og størrelsen på husstanden din. Standarden skal være
                     nøktern og rimelig.
-                </Normaltekst>
-                <br />
+                </Avsnitt>
+
                 <Undertittel tag="h3">
                     Depositum og garanti for depositum
                 </Undertittel>
-                <br />
-                <Normaltekst>
+                <Avsnitt>
                     En utleier av en leiebolig krever normalt sikkerhet for ikke
                     betalt leie, skader og andre krav som følger av leieavtalen.
                     Du kan søke om stønad til depositum når du inngår en
@@ -102,26 +98,26 @@ const DetteKanDuSokeOmBokmal: React.FC = () => {
                     andre måter. NAV gir vanligvis hjelp i form av garanti for
                     depositum, men NAV kan også gi økonomisk stønad til
                     depositum på en sperret depositumskonto.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Når NAV gir garanti for depositum blir det ikke utbetalt
                     penger. NAV skriver et garantidokument til utleier. Hvilke
                     krav garantien dekker kan variere fra kommune til kommune.
                     Hvis hele eller deler av garantien eller depositumet blir
                     utbetalt, vil dette normalt bli et lån som du må
                     tilbakebetale. NAV vil da vurdere din tilbakebetalingsevne.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Partene i leieforholdet er utleier og leietager og dette
                     blir ikke endret selv om NAV har gitt hjelp til depositum
                     eller garanti for depositum.
-                </Normaltekst>
+                </Avsnitt>
             </Ekspanderbartpanel>
 
             <Ekspanderbartpanel tittel="helse og tannbehandling" border>
-                <Normaltekst>
+                <Avsnitt>
                     Utgifter til lege, psykolog, tannlege, viktige legemidler og
                     syns- og hørselshjelpemidler kan i noen tilfeller bli dekket
                     gjennom folketrygdloven ved Helfo. Du har i utgangspunktet
@@ -134,30 +130,29 @@ const DetteKanDuSokeOmBokmal: React.FC = () => {
                         helsenorge.no
                     </Lenke>
                     .
-                </Normaltekst>
-                <br />
+                </Avsnitt>
+
                 <Undertittel tag="h3">
                     Om dekning av utgifter til tannbehandling
                 </Undertittel>
-                <br />
-                <Normaltekst>
+                <Avsnitt>
                     Som hovedregel må voksne betale utgiftene til tannbehandling
                     selv, men det finnes enkelte unntak hvis du har visse
                     sykdommer, tilstander eller skader. Tannlegen skal vurdere
                     om du faller inn under noen av disse unntakene, og derfor
                     kan ha rett på støtte fra Helfo.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Hvis du har problemer med å betale regningen, kan du høre
                     med tannlegen din om det er mulig å lage en behandlingsplan
                     med nedbetalingsavtale. Hvis du ikke har krav på støtte fra
                     Helfo til tannbehandling, og du heller ikke har økonomi til
                     å få laget en nedbetalingsavtale, kan du søke NAV om å få
                     dekket disse utgiftene helt eller delvis.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     For at vi skal kunne vurdere saken din, må du legge ved
                     nødvendig dokumentasjon. I tillegg til dokumentasjon på
                     inntekter, utgifter og formue, trenger NAV et
@@ -168,48 +163,48 @@ const DetteKanDuSokeOmBokmal: React.FC = () => {
                     </Lenke>{" "}
                     fra tannlege til tannlege, og NAV kan begrense stønaden til
                     å dekke et rimelig behandlingsalternativ.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Ved akutt tannbehandling må du legge ved faktura og en
                     uttalelse fra tannlegen.
-                </Normaltekst>
+                </Avsnitt>
             </Ekspanderbartpanel>
 
             <Undertittel>Har du gjeldsproblemer?</Undertittel>
-
-            <Normaltekst>
+            <Avsnitt>
                 Du kan i utgangspunktet ikke få dekket utgifter til gjeld. Hvis
                 du har gjeld, kan du få økonomisk rådgivning og hjelp til å
                 inngå avtale med kreditor. Hjelpen kan blant annet bestå i å
                 inngå avtale om en nedbetalingsplan, endrede lånevilkår eller
                 betalingsutsettelse.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 I enkelte tilfeller kan NAV vurdere å dekke utgifter til gjeld,
                 for eksempel når det er fare for å miste strømmen eller boligen
                 og det ikke finnes andre muligheter for å forhindre dette.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Hvordan søker du?</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 Du skal søke til NAV-kontoret der du bor. Stadig flere kommuner
                 kan ta i mot digitale søknader. Hvis du ikke skal søke digitalt,
                 kan du søke med kommunens papirskjema.
-            </Normaltekst>
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 <Lenke href={"/sosialhjelp/slik-soker-du?lang=nb"}>
                     Søk her.
                 </Lenke>
-                <br />
-                <br />
+            </Avsnitt>
+            <Avsnitt>
                 For mer informasjon, se{" "}
                 <Lenke href={"/sosialhjelp/dette-bor-du-vite?lang=nb"}>
                     dette bør du vite før du søker
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/dette-kan-du-soke-om/DetteKanDuSokeOmEnglish.tsx
+++ b/src/artikler/dette-kan-du-soke-om/DetteKanDuSokeOmEnglish.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
-import {Normaltekst, Innholdstittel, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import Lenke from "nav-frontend-lenker";
 import Artikkel from "../Artikkel";
 import "../artikkel.less";
 import IllustrasjonBygningPerson from "../../komponenter/bilder/IllustrasjonBygningPerson";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const DetteKanDuSokeOmEnglish: React.FC = () => {
     return (
@@ -15,74 +16,74 @@ const DetteKanDuSokeOmEnglish: React.FC = () => {
             }
         >
             <Innholdstittel>You can apply for this</Innholdstittel>
-            <Normaltekst>
+            <Avsnitt>
                 We will work with you to find out what your financial assistance
                 needs are. How much financial assistance you qualify for will
                 depend on your family situation, the number of people in your
                 household, your living situation, etc. We assess each individual
                 case separately. Below are some examples of types of assistance
                 you can apply for to NAV.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Costs</Undertittel>
 
             <Ekspanderbartpanel tittel="Living costs" border={true}>
-                <Normaltekst>
+                <Avsnitt>
                     Basic needs, such as food, clothing, housing and heating,
                     are often referred to as subsistence needs when we make
                     decisions concerning financial assistance.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     NAV also includes costs related to certain hobbies or
                     sports, telephone, TV or Internet costs, transport costs and
                     medical or dental costs when assessing your subsistence
                     needs. We will also consider whether you have any special
                     added expenses we should take into account. We will
                     emphasize the needs of children and youths.
-                </Normaltekst>
+                </Avsnitt>
             </Ekspanderbartpanel>
 
             <Ekspanderbartpanel tittel="Housing costs" border={true}>
                 <Undertittel tag="h3">
                     Housing costs and electricity
                 </Undertittel>
-                <br />
-                <Normaltekst>
+
+                <Avsnitt>
                     You may apply for assistance in paying recurrent housing
                     costs, such as rent, municipal charges, fixed costs in a
                     housing cooperative, estate in common, etc., and payment of
                     interest on your mortgage. If you have a mortgage, we will
                     ask you to contact your bank and apply for a grace period
                     where you don’t have to pay instalments.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     You may also apply for assistance in paying for heating and
                     electricity.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     If your housing costs are so high that you are unable to pay
                     them with your current or expected income, we may require
                     you to reduce your housing costs. This may entail moving to
                     a more affordable home. In such situations, it is important
                     to consider the needs of children and youths in terms of
                     disrupting their social network as little as possible.
-                </Normaltekst>
-                <br />
+                </Avsnitt>
+
                 <Undertittel tag="h3">Moving</Undertittel>
-                <br />
-                <Normaltekst>
+
+                <Avsnitt>
                     NAV may consider providing assistance in helping you pay for
                     necessary moving costs. This is particularly relevant if NAV
                     has required you to move to reduce your housing costs, or if
                     there are other special reasons that require you to move.
-                </Normaltekst>
-                <br />
+                </Avsnitt>
+
                 <Undertittel tag="h3">Household effects</Undertittel>
-                <br />
-                <Normaltekst>
+
+                <Avsnitt>
                     You may apply for assistance in acquiring the necessities in
                     terms of household effects if you do not have the means to
                     pay for these yourself. NAV will determine what is
@@ -90,13 +91,13 @@ const DetteKanDuSokeOmEnglish: React.FC = () => {
                     needs, living situation, age and the number of people in
                     your household. The standard of effects is expected to be
                     modest and reasonable.
-                </Normaltekst>
-                <br />
+                </Avsnitt>
+
                 <Undertittel tag="h3">
                     Deposit and deposit guarantee
                 </Undertittel>
-                <br />
-                <Normaltekst>
+
+                <Avsnitt>
                     A landlord normally requires a security deposit intended to
                     cover any unpaid rent, damage and other claims under the
                     terms of the lease. You may apply for assistance in covering
@@ -105,9 +106,9 @@ const DetteKanDuSokeOmEnglish: React.FC = () => {
                     this type of assistance in the form of a deposit guarantee,
                     but NAV may also offer financial assistance in the form of a
                     deposit to an escrow account.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     When NAV puts up a deposit guarantee, no money is paid.
                     Instead, NAV will issue a guarantee certificate to the
                     landlord. What this guarantee covers will vary from
@@ -115,17 +116,17 @@ const DetteKanDuSokeOmEnglish: React.FC = () => {
                     guarantee amount or deposit is paid, this will normally be
                     converted to a loan, for which you are liable. NAV will
                     therefore assess your ability to repay such a loan.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     The parties to the lease are the landlord and the lessee,
                     and this does not change even if NAV has provided assistance
                     to cover the deposit or issued a deposit guarantee.
-                </Normaltekst>
+                </Avsnitt>
             </Ekspanderbartpanel>
 
             <Ekspanderbartpanel tittel="Medical and dental costs" border={true}>
-                <Normaltekst>
+                <Avsnitt>
                     Costs incurred in connection with appointments with a
                     physician, psychologist or dentist and acquiring necessary
                     medication or visual or hearing impairment aids may
@@ -145,30 +146,32 @@ const DetteKanDuSokeOmEnglish: React.FC = () => {
                         helsenorge.no
                     </Lenke>
                     .
-                </Normaltekst>
-                <br />
-                <Undertittel tag="h3">
-                    About assistance with dental costs
-                </Undertittel>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
+                    <Undertittel tag="h3">
+                        About assistance with dental costs
+                    </Undertittel>
+                </Avsnitt>
+
+                <Avsnitt>
                     As a norm, adults are expected to cover their own dental
                     costs, but there are certain exceptions if you have certain
                     diseases, conditions or injuries. Your dentist will consider
                     whether any of these exceptions apply to you, and if they
                     do, you may qualify for assistance from Helfo.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     If you have a hard time covering the bill, contact your
                     dentist to see if it is possible to devise some sort of
                     payment plan for your treatment. If you do not qualify for
                     assistance from Helfo, and your financial situation makes it
                     impossible to come up with a payment plan, you may apply to
                     NAV for assistance in covering some or all of these costs.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     For NAV to be able to assess your case, you must submit all
                     necessary documentation. In addition to documentation of
                     your income, expenses and assets, NAV requires a cost
@@ -177,55 +180,56 @@ const DetteKanDuSokeOmEnglish: React.FC = () => {
                     treatment.{" "}
                     <Lenke href={"https://www.hvakostertannlegen.no/"}>
                         Prices may vary
-                    </Lenke>
-                    &nbsp;from dentist to dentist, and NAV may limit your
-                    application to a reasonable treatment option.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                    </Lenke>{" "}
+                    from dentist to dentist, and NAV may limit your application
+                    to a reasonable treatment option.
+                </Avsnitt>
+
+                <Avsnitt>
                     If you had to have emergency dental treatment, you must
                     include the bill and a statement from your dentist.
-                </Normaltekst>
+                </Avsnitt>
             </Ekspanderbartpanel>
 
             <Undertittel>Do you have trouble paying your debt?</Undertittel>
-
-            <Normaltekst>
+            <Avsnitt>
                 As a norm, social assistance cannot be used to pay debts. If you
                 have debts, we can offer financial counselling and help you
                 reach an agreement with your creditors. This help may include
                 assistance in establishing a payment plan, changing the terms of
                 your loan or applying for a grace period.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Under special circumstances NAV may consider covering debt
                 payment costs, for example when you are at risk of having your
                 electricity cut off or losing your home, and there are no other
                 ways to prevent this from happening.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>How to apply</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 You must submit your application to the NAV office in the
                 municipality where you live. A growing number of municipalities
                 support online applications. If your municipality does not
                 support online applications, you can contact your local NAV
                 office to obtains the paper form.
-            </Normaltekst>
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 <Lenke href={"/sosialhjelp/slik-soker-du?lang=en"}>
                     Apply here
                 </Lenke>
                 .
-                <br />
-                <br />
+            </Avsnitt>
+
+            <Avsnitt>
                 For more information, see{" "}
                 <Lenke href={"/sosialhjelp/dette-bor-du-vite?lang=en"}>
                     what you should know before applying
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/dette-kan-du-soke-om/DetteKanDuSokeOmNynorsk.tsx
+++ b/src/artikler/dette-kan-du-soke-om/DetteKanDuSokeOmNynorsk.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import "../artikkel.less";
-import {Normaltekst, Innholdstittel, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import Lenke from "nav-frontend-lenker";
 import Artikkel from "../Artikkel";
 import IllustrasjonBygningPerson from "../../komponenter/bilder/IllustrasjonBygningPerson";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const DetteKanDuSokeOmNynorsk: React.FC = () => {
     return (
@@ -15,88 +16,86 @@ const DetteKanDuSokeOmNynorsk: React.FC = () => {
             }
         >
             <Innholdstittel>Dette kan du søkje om</Innholdstittel>
-            <Normaltekst>
+            <Avsnitt>
                 Vi vurderer saman med deg kva behovet ditt er for økonomisk
                 sosialhjelp. Kor mykje du kan få i stønad er avhengig av din
                 familiesituasjon, talet på personar som høyrer til hushaldet,
                 butilhøve, med meir. Vi fastset stønaden etter ei individuell
                 vurdering i kvar enkelt sak. Under ser du døme på kva du kan
                 søkje NAV-kontoret ditt om.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Utgifter du kan søkje om å få hjelp med</Undertittel>
 
-            <Normaltekst>
-                Du kan søkje om å få hjelp med utgifter til
-            </Normaltekst>
+            <Avsnitt>Du kan søkje om å få hjelp med utgifter til</Avsnitt>
 
             <Ekspanderbartpanel tittel="å leve" border>
-                <Normaltekst>
+                <Avsnitt>
                     Dei heilt grunnleggande behova som mat, klede, bustad og
                     oppvarming omtalar vi ofte som livsopphald når vi gjer eit
                     vedtak om sosialhjelp.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Også utgifter til fritidsaktiviteter, telefoni, tv,
                     internett, transport og helse- og tannbehandling blir av NAV
                     rekna som en del av livsopphaldet. Vi vurderer òg om du har
                     særlege ekstrautgifter som vi bør ta omsyn til. Vi legg
                     særleg vekt på barn og unge sine behov.
-                </Normaltekst>
+                </Avsnitt>
             </Ekspanderbartpanel>
 
             <Ekspanderbartpanel tittel="å bo" border>
                 <Undertittel tag="h3">Bu- og straumutgifter</Undertittel>
-                <br />
-                <Normaltekst>
+
+                <Avsnitt>
                     Du kan søkje om å få dekt laupande utgifter til bustad, som
                     husleige, kommunale avgifter, faste utgifter i burettslag,
                     sameige og liknande, og betaling av renter på bustadlån. Har
                     du bustadlån vil vi be deg søkje banken om ein periode der
                     du ikkje betalar avdrag.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Du kan òg søkje om å få dekt laupande utgifter til straum og
                     oppvarming.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Dersom buutgiftene dine er så høge at du ikkje er i stand
                     til å betene dei med inntektene du har eller kan forvente å
                     få, kan vi stille krav om at du må redusere buutgiftene
                     dine. Det kan bety at du må flytte til ein rimelegare
                     bustad. I slike situasjonar er det viktig å ta omsyn til det
                     behovet barn og unge har for å halde på nettverket sitt.
-                </Normaltekst>
-                <br />
+                </Avsnitt>
+
                 <Undertittel tag="h3">Flytting</Undertittel>
-                <br />
-                <Normaltekst>
+
+                <Avsnitt>
                     NAV kan vurdere å gi stønad til nødvendige utgifter til
                     flytting. Særleg aktuelt er dette dersom det er NAV-kontoret
                     som har pålagt deg å flytte for å redusere buutgiftene,
                     eller dersom det er andre særskilde grunnar til at du må
                     flytte.
-                </Normaltekst>
-                <br />
+                </Avsnitt>
+
                 <Undertittel tag="h3">Innbu og utstyr</Undertittel>
-                <br />
-                <Normaltekst>
+
+                <Avsnitt>
                     Du kan søkje om stønad til det mest nødvendige av innbu og
                     utstyr til å bu i ein bustad, dersom du ikkje har økonomi
                     til å skaffe dette på andre måtar. NAV vurderer kva som er
                     nødvendig utstyr ut frå individuelle behov, livssituasjon,
                     alder og størrelse på husstanden din. Standarden skal vere
                     nøktern og rimeleg.
-                </Normaltekst>
-                <br />
+                </Avsnitt>
+
                 <Undertittel tag="h3">
                     Depositum og garanti for depositum
                 </Undertittel>
-                <br />
-                <Normaltekst>
+
+                <Avsnitt>
                     Ein utleigar av ein leigebustad krev normalt tryggleik for
                     leige som ikkje blir betalt, skadar og andre krav som
                     følgjer av leigeavtalen. Du kan søkje om stønad til
@@ -105,26 +104,26 @@ const DetteKanDuSokeOmNynorsk: React.FC = () => {
                     vanlegvis hjelp i form av garanti for depositum, men NAV kan
                     også gi økonomisk stønad til depositum på ein sperra
                     depositumskonto.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Når NAV gir garanti for depositum blir det ikkje utbetalt
                     pengar. NAV skriv eit garantidokument til utleigar. Kva krav
                     garantien dekkjer kan variere frå kommune til kommune.
                     Dersom heile eller deler av garantien eller depositumet blir
                     utbetalt, vil dette normalt bli eit lån som du må betale
                     tilbake. NAV vil då vurdere din tilbakebetalingsevne.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Partane i leigeforholdet er utleigar og leigetakar og dette
                     blir ikkje endra sjølv om NAV har gitt hjelp til depositum
                     eller garanti for depositum.
-                </Normaltekst>
+                </Avsnitt>
             </Ekspanderbartpanel>
 
             <Ekspanderbartpanel tittel="helse og tannbehandling" border>
-                <Normaltekst>
+                <Avsnitt>
                     Utgifter til lege, psykolog, tannlege, viktige legemidlar og
                     syns- og hørselshjelpemidlar kan i nokre tilfelle bli dekt
                     gjennom folketrygdlova ved Helfo. Du har i utgangspunktet
@@ -138,21 +137,21 @@ const DetteKanDuSokeOmNynorsk: React.FC = () => {
                         helsenorge.no
                     </Lenke>
                     .
-                </Normaltekst>
-                <br />
+                </Avsnitt>
+
                 <Undertittel tag="h3">
                     Om dekning av utgifter til tannbehandling
                 </Undertittel>
-                <br />
-                <Normaltekst>
+
+                <Avsnitt>
                     Som hovudregel må vaksne betale utgiftene til tannbehandling
                     sjølv, men det finst enkelte unntak dersom du har visse
                     sjukdommar, tilstandar eller skadar. Tannlegen skal vurdere
                     om du fell inn under nokre av disse unntaka, og difor kan ha
                     rett på støtte frå Helfo.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Dersom du har problem med å betale rekninga, kan du høyre
                     med tannlegen din om det er mogleg å lage ein
                     behandlingsplan med nedbetalingsavtale. Dersom du ikkje har
@@ -160,9 +159,9 @@ const DetteKanDuSokeOmNynorsk: React.FC = () => {
                     ikkje har økonomi til å få lage ein nedbetalingsavtale, kan
                     du søkje NAV om å få dekt desse utgiftene heilt eller
                     delvis.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     For at vi skal kunne vurdere saka di, må du leggje ved
                     nødvendig dokumentasjon. I tillegg til dokumentasjon på
                     inntekter, utgifter og formue, treng NAV eit
@@ -173,48 +172,49 @@ const DetteKanDuSokeOmNynorsk: React.FC = () => {
                     </Lenke>{" "}
                     frå tannlege til tannlege, og NAV kan avgrense stønaden til
                     å dekkje eit rimeleg behandlingsalternativ.
-                </Normaltekst>
-                <br />
-                <Normaltekst>
+                </Avsnitt>
+
+                <Avsnitt>
                     Ved akutt tannbehandling må du legge ved faktura og ei
                     melding frå tannlegen.
-                </Normaltekst>
+                </Avsnitt>
             </Ekspanderbartpanel>
 
             <Undertittel>Har du gjeldsproblem?</Undertittel>
 
-            <Normaltekst>
+            <Avsnitt>
                 Du kan i utgangspunktet ikkje få dekt utgifter til gjeld. Viss
                 du har gjeld, kan du få økonomisk rådgjeving og hjelp til å
                 inngå avtale med kreditor. Hjelpa kan blant anna bestå i å inngå
                 avtale om ein nedbetalingsplan, endre lånevilkår eller
                 betalingsutsetting.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 I enkelte tilfelle kan NAV vurdere å dekkje utgifter til gjeld,
                 til dømes når det er fare for å miste straumen eller bustaden og
                 det ikkje finst andre moglege løysingar for å hindre dette.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Korleis søkjer du?</Undertittel>
-            <Normaltekst>
+
+            <Avsnitt>
                 Du skal søkje til NAV-kontoret der du bor. Stadig fleire
                 kommunar kan ta i mot digitale søknader. Dersom du ikkje skal
                 søkje digitalt, kan du søkje med kommunens papirskjema.
-            </Normaltekst>
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 <Lenke href={"sosialhjelp/slik-soker-du?lang=nn"}>
                     Søk her.
                 </Lenke>
-                <br />
-                <br />
+            </Avsnitt>
+            <Avsnitt>
                 For meir informasjon, sjå{" "}
                 <Lenke href={"/sosialhjelp/dette-bor-du-vite?lang=nn"}>
                     dette bør du vite før du søkjer
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/ettersende/EttersendeBokmal.tsx
+++ b/src/artikler/ettersende/EttersendeBokmal.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 import Artikkel from "../Artikkel";
 import "../artikkel.less";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const EttersendeBokmal: React.FC = () => {
     return (
@@ -12,9 +13,10 @@ const EttersendeBokmal: React.FC = () => {
             </Innholdstittel>
 
             <Undertittel>Hvis du har søkt digitalt</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 Du kan ettersende dokumenter digitalt. Det gjør du ved å:
-            </Normaltekst>
+            </Avsnitt>
+
             <div className="typo-normal">
                 <ul>
                     <li>
@@ -27,13 +29,13 @@ const EttersendeBokmal: React.FC = () => {
                     <li>Last opp dokumentene du skal ettersende</li>
                 </ul>
             </div>
-            <Normaltekst>
+
+            <Avsnitt>
                 Pass på at du ettersender til den riktige søknaden.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Hvis du har søkt på papir</Undertittel>
-
-            <Normaltekst>
+            <Avsnitt>
                 Har du søkt på papir, må du levere dokumentasjonen til{" "}
                 <Lenke
                     href={
@@ -43,7 +45,7 @@ const EttersendeBokmal: React.FC = () => {
                     ditt NAV-kontor
                 </Lenke>
                 . Du kan også sende det i posten.
-            </Normaltekst>
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/gi-beskjed/GiBeskjedBokmal.tsx
+++ b/src/artikler/gi-beskjed/GiBeskjedBokmal.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const GiBeskjedBokmal: React.FC = () => (
     <Artikkel
@@ -11,19 +12,21 @@ const GiBeskjedBokmal: React.FC = () => (
         illustrasjon={<Veiskilft className="illustrasjon" />}
     >
         <Innholdstittel>Meld fra om endringer</Innholdstittel>
-        <Normaltekst>
+
+        <Avsnitt>
             Hvis du får endringer i inntekt, familiesituasjon og/eller
             jobbsituasjon, eller planlegger opphold i utlandet, kan det ha
             betydning for beløpet du får utbetalt fra NAV. I slike tilfeller må
             du derfor straks melde fra til NAV. Er du gift eller registrert
             partner, må du også melde fra hvis det skjer endringer i situasjonen
             til ektefellen/partneren din.
-        </Normaltekst>
-        <br />
+        </Avsnitt>
+
         <Undertittel>
             Dette er eksempler på situasjoner som kan påvirke utbetalingen din:
         </Undertittel>
-        <Normaltekst>
+
+        <div className="typo-normal">
             <ul>
                 <li>
                     du begynner å tjene mer eller mindre enn du tidligere har
@@ -45,8 +48,9 @@ const GiBeskjedBokmal: React.FC = () => (
                 <li>du planlegger et opphold i eller flytting til utlandet</li>
                 <li>du skal flytte ut av kommunen</li>
             </ul>
-        </Normaltekst>
-        <Normaltekst>
+        </div>
+
+        <Avsnitt>
             Hvis du er usikker på om endringen vil virke inn på utbetalingen
             din, kan du lese mer i vedtaksbrevet du har fått fra oss. Du kan
             også ta kontakt med oss på{" "}
@@ -58,7 +62,7 @@ const GiBeskjedBokmal: React.FC = () => (
                 telefon
             </Lenke>
             .
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/gi-beskjed/GiBeskjedEnglish.tsx
+++ b/src/artikler/gi-beskjed/GiBeskjedEnglish.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const GiBeskjedEnglish: React.FC = () => (
     <Artikkel
@@ -13,16 +14,18 @@ const GiBeskjedEnglish: React.FC = () => (
         <Innholdstittel>
             Notify us of any changes to your situation
         </Innholdstittel>
-        <Normaltekst>
+
+        <Avsnitt>
             Any changes in your situation that may affect the payment you
             receive from the Norwegian Labour and Welfare Administration (NAV)
             must immediately be reported to your local NAV office. This includes
             changes in the situation of your spouse or partner if you are
             married or have a registered partnership.
-        </Normaltekst>
-        <br />
+        </Avsnitt>
+
         <Undertittel>For example, you must notify us if:</Undertittel>
-        <Normaltekst>
+
+        <div className="typo-normal">
             <ul>
                 <li>
                     you start earning more or less than you have previously told
@@ -45,8 +48,9 @@ const GiBeskjedEnglish: React.FC = () => (
                 <li>you will be staying abroad</li>
                 <li>you plan to move out of the municipality</li>
             </ul>
-        </Normaltekst>
-        <Normaltekst>
+        </div>
+
+        <Avsnitt>
             If you are not sure whether the change in your situation will affect
             your payments, you can find more information in the letter we have
             sent you advising you of our decision in your case. You can also
@@ -59,7 +63,7 @@ const GiBeskjedEnglish: React.FC = () => (
                 phone
             </Lenke>
             .
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/gi-beskjed/GiBeskjedNynorsk.tsx
+++ b/src/artikler/gi-beskjed/GiBeskjedNynorsk.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const GiBeskjedNynorsk: React.FC = () => (
     <Artikkel
@@ -11,19 +12,21 @@ const GiBeskjedNynorsk: React.FC = () => (
         illustrasjon={<Veiskilft className="illustrasjon" />}
     >
         <Innholdstittel>Meld frå om endringar</Innholdstittel>
-        <Normaltekst>
+
+        <Avsnitt>
             Dersom du får endringar i inntekt, familiesituasjon og/eller
             jobbsituasjon, eller planlegger opphald i utlandet, kan det ha
             betyding for beløpet du får utbetalt frå NAV. I slike tilfeller må
             du derfor straks melde frå til NAV. Er du gift eller registrert
             partner, må du også melde frå dersom det skjer endringar i
             situasjonen til ektefellen/partnaren din.
-        </Normaltekst>
-        <br />
+        </Avsnitt>
+
         <Undertittel>
             Døme på forhold som kan ha innverknad på utbetalinga di:
         </Undertittel>
-        <Normaltekst>
+
+        <div className="typo-normal">
             <ul>
                 <li>
                     du begynner å tene meir eller mindre enn du tidlegare har
@@ -46,8 +49,9 @@ const GiBeskjedNynorsk: React.FC = () => (
                 <li>du planleggar eit opphald i eller flytting til utlandet</li>
                 <li>du skal flytte ut av kommunen</li>
             </ul>
-        </Normaltekst>
-        <Normaltekst>
+        </div>
+
+        <Avsnitt>
             Dersom du er usikker på om endringa har betyding for utbetalinga di,
             kan du lese meir i vedtaksbrevet du har fått frå oss. Du kan òg ta
             kontakt med oss på{" "}
@@ -59,7 +63,7 @@ const GiBeskjedNynorsk: React.FC = () => (
                 telefon
             </Lenke>
             .
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/hvis-du-er-enslig-forsorger/HvisDuErEnsligForsorgerBokmal.tsx
+++ b/src/artikler/hvis-du-er-enslig-forsorger/HvisDuErEnsligForsorgerBokmal.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import Lenke from "nav-frontend-lenker";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import {andreMuligheterBrodsmulestiBokmal} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const HvisDuErEnsligForsorgerBokmal = () => (
     <Artikkel
@@ -14,42 +15,44 @@ const HvisDuErEnsligForsorgerBokmal = () => (
         foreldreside={andreMuligheterBrodsmulestiBokmal}
     >
         <Innholdstittel>Hvis du er enslig forsørger</Innholdstittel>
-        <Normaltekst>
+
+        <Avsnitt>
             Det er flere stønader og ordninger som kan være aktuelle for deg som
             er enslig mor eller far.
-        </Normaltekst>
+        </Avsnitt>
+
         <Ekspanderbartpanel tittel="Utvidet barnetrygd" border>
-            <Normaltekst>
+            <Avsnitt>
                 Du kan ha rett til barnetrygd for ett barn mer enn du faktisk
                 bor sammen med hvis du bor alene med barn. Les mer om{" "}
                 <Lenke href="https://www.nav.no/no/Person/Familie/Barnetrygd+og+kontantstotte/barnetrygd--156">
                     utvidet barnetrygd
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Overgangsstønad" border>
-            <Normaltekst>
+            <Avsnitt>
                 Du kan ha rett til overgangsstønad hvis du ikke har mulighet til
                 å forsørge deg selv på grunn av omsorg for barnet. Les mer om
                 <Lenke href="https://www.nav.no/no/Person/Familie/Enslig+mor+eller+far/Overgangsst%C3%B8nad.1039.cms">
                     overgangsstønad
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Stønad til barnetilsyn" border>
-            <Normaltekst>
+            <Avsnitt>
                 Stønad til barnetilsyn skal dekke deler av kostnadene til
                 barnetilsyn på grunn av arbeid. Les mer om{" "}
                 <Lenke href="https://www.nav.no/no/Person/Familie/Enslig+mor+eller+far/Nynorsk/barnetilsyn+p%C3%A5+grunn+av+arbeid">
                     stønad til barnetilsyn
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Tilleggsstønader" border>
-            <Normaltekst>
+            <Avsnitt>
                 Du kan ha rett til helt eller delvis få dekket utgifter du har
                 hvis du gjennomfører nødvendig og hensiktsmessig utdanning, er
                 registrert hos NAV som reell arbeidssøker, eller hvis du må
@@ -58,10 +61,10 @@ const HvisDuErEnsligForsorgerBokmal = () => (
                     tilleggsstønader og stønad til skolepenger
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Barnebidrag" border>
-            <Normaltekst>
+            <Avsnitt>
                 Hvis foreldrene til et barn ikke bor sammen, må den som ikke har
                 barnet boende hos seg betale sin andel som barnebidrag til den
                 andre. Det kan også være aktuelt å betale barnebidrag når barnet
@@ -70,10 +73,10 @@ const HvisDuErEnsligForsorgerBokmal = () => (
                     barnebidrag
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Bidragsforskudd" border>
-            <Normaltekst>
+            <Avsnitt>
                 Bidragsforskudd fra NAV skal sikre at barn får et beløp hver
                 måned hvis barnebidraget av ulike årsaker ikke blir betalt. Les
                 mer om{" "}
@@ -81,10 +84,10 @@ const HvisDuErEnsligForsorgerBokmal = () => (
                     bidragsforskudd
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Særtilskudd" border>
-            <Normaltekst>
+            <Avsnitt>
                 Ved spesielle utgifter som tannregulering, konfirmasjon og
                 briller, kan forelderen med utgiftene søke om at den andre
                 betaler sin del. Les mer om{" "}
@@ -92,7 +95,7 @@ const HvisDuErEnsligForsorgerBokmal = () => (
                     særtilskudd
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
     </Artikkel>
 );

--- a/src/artikler/hvis-du-er-enslig-forsorger/HvisDuErEnsligForsorgerEnglish.tsx
+++ b/src/artikler/hvis-du-er-enslig-forsorger/HvisDuErEnsligForsorgerEnglish.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import Lenke from "nav-frontend-lenker";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import {andreMuligheterBrodsmulestiEngelsk} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const HvisDuErEnsligForsorgerEnglish = () => (
     <Artikkel
@@ -14,12 +15,14 @@ const HvisDuErEnsligForsorgerEnglish = () => (
         foreldreside={andreMuligheterBrodsmulestiEngelsk}
     >
         <Innholdstittel>If you are a single parent</Innholdstittel>
-        <Normaltekst>
+
+        <Avsnitt>
             You may qualify for several different benefits and programmes as a
             single mother or father.
-        </Normaltekst>
+        </Avsnitt>
+
         <Ekspanderbartpanel tittel="Extended child benefit" border>
-            <Normaltekst>
+            <Avsnitt>
                 You may qualify for child benefits for one child more than the
                 number of children in your household if you live alone with
                 children. Read more about{" "}
@@ -27,10 +30,10 @@ const HvisDuErEnsligForsorgerEnglish = () => (
                     extended child benefits
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Transitional benefit" border>
-            <Normaltekst>
+            <Avsnitt>
                 You may qualify for transitional benefits if you are unable to
                 provide for yourself as a result of caring for the child. Read
                 more about{" "}
@@ -38,20 +41,20 @@ const HvisDuErEnsligForsorgerEnglish = () => (
                     transitional benefits
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Child care benefit" border>
-            <Normaltekst>
+            <Avsnitt>
                 Child care benefits are intended to cover part of the cost of
                 child care as a result of employment. Read more about{" "}
                 <Lenke href="https://www.nav.no/en/Home/Benefits+and+services/Relatert+informasjon/child-care-benefit">
                     child care benefit
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Supplemental benefits" border>
-            <Normaltekst>
+            <Avsnitt>
                 You may qualify to have some or all of your expenses covered by
                 NAV if these expenses are incurred as a result of necessary and
                 relevant education, your registration with NAV as a genuine job
@@ -61,10 +64,10 @@ const HvisDuErEnsligForsorgerEnglish = () => (
                     supplemental benefits and allowances to cover tuition fees
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Child support" border>
-            <Normaltekst>
+            <Avsnitt>
                 If the parents of a child do not live together, the person with
                 whom the child does not live must pay his or her share of the
                 costs as child support to the other parent. Child support
@@ -74,10 +77,10 @@ const HvisDuErEnsligForsorgerEnglish = () => (
                     child support
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Advance payments of child support" border>
-            <Normaltekst>
+            <Avsnitt>
                 Advance payments of child support from NAV serve to ensure that
                 children receive payment every month, even if the child support
                 is not paid for whatever reason. Read more about{" "}
@@ -85,10 +88,10 @@ const HvisDuErEnsligForsorgerEnglish = () => (
                     advance payments of child support
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Extraordinary child support" border>
-            <Normaltekst>
+            <Avsnitt>
                 In connection with extraordinary expenses, such as orthodontics,
                 the child’s confirmation or new glasses, the parent bearing the
                 expense can apply for the other parent to cover his or her
@@ -97,7 +100,7 @@ const HvisDuErEnsligForsorgerEnglish = () => (
                     extraordinary child support (text in Norwegian)
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
     </Artikkel>
 );

--- a/src/artikler/hvis-du-er-enslig-forsorger/HvisDuErEnsligForsorgerNynorsk.tsx
+++ b/src/artikler/hvis-du-er-enslig-forsorger/HvisDuErEnsligForsorgerNynorsk.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import Lenke from "nav-frontend-lenker";
 import {andreMuligheterBrodsmulestiNynorsk} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const HvisDuErEnsligForsorgerNynorsk = () => (
     <Artikkel
@@ -14,22 +15,24 @@ const HvisDuErEnsligForsorgerNynorsk = () => (
         foreldreside={andreMuligheterBrodsmulestiNynorsk}
     >
         <Innholdstittel>Dersom du er einsleg forsørgjar</Innholdstittel>
-        <Normaltekst>
+
+        <Avsnitt>
             Det er fleire stønadar og ordningar som kan vere aktuelle for deg
             som er einsleg mor eller far.
-        </Normaltekst>
+        </Avsnitt>
+
         <Ekspanderbartpanel tittel="Utvida barnetrygd" border>
-            <Normaltekst>
+            <Avsnitt>
                 Du kan ha rett til barnetrygd for eitt barn meir enn du faktisk
                 bur saman med om du bur aleine med barn. Les meir om{" "}
                 <Lenke href="https://www.nav.no/no/Person/Familie/Barnetrygd+og+kontantstotte/barnetrygd--156">
                     utvida barnetrygd
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Overgangsstønad" border>
-            <Normaltekst>
+            <Avsnitt>
                 Du kan ha rett til overgangsstønad om du ikkje har moglegheit
                 til å forsørgje deg sjølv på grunn av omsorg for barnet. Les
                 meir om{" "}
@@ -37,20 +40,20 @@ const HvisDuErEnsligForsorgerNynorsk = () => (
                     overgangsstønad
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Stønad til barnetilsyn" border>
-            <Normaltekst>
+            <Avsnitt>
                 Stønad til barnetilsyn skal dekkje deler av kostnadene til
                 barnetilsyn på grunn av arbeid. Les meir om{" "}
                 <Lenke href="https://www.nav.no/no/Person/Familie/Enslig+mor+eller+far/Nynorsk/barnetilsyn+p%C3%A5+grunn+av+arbeid">
                     stønad til barnetilsyn
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Tilleggsstønader" border>
-            <Normaltekst>
+            <Avsnitt>
                 Du kan ha rett til å heilt eller delvis få dekt utgifter du har
                 om du gjennomfører nødvendig og hensiktsmessig utdanning, er
                 registrert hos NAV som reell arbeidssøkjar, eller om du må
@@ -59,10 +62,10 @@ const HvisDuErEnsligForsorgerNynorsk = () => (
                     tilleggsstønader og stønad til skulepengar
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Barnebidrag" border>
-            <Normaltekst>
+            <Avsnitt>
                 Dersom foreldra til eit barn ikkje bur saman, må den som ikkje
                 har barnet buande hos seg betale sin del som barnebidraget til
                 den andre. Det kan òg vere aktuelt å betale barnebidrag når
@@ -71,10 +74,10 @@ const HvisDuErEnsligForsorgerNynorsk = () => (
                     barnebidrag
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Bidragsforskot" border>
-            <Normaltekst>
+            <Avsnitt>
                 Bidragsforskot frå NAV skal sikre at barn får eit beløp kvar
                 månad om barnebidraget av ulike grunnar ikkje blir betalt. Les
                 meir om{" "}
@@ -82,10 +85,10 @@ const HvisDuErEnsligForsorgerNynorsk = () => (
                     bidragsforskot
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Særtilskot" border>
-            <Normaltekst>
+            <Avsnitt>
                 Ved særskilde utgifter som tannregulering, konfirmasjon og
                 briller, kan forelderen med utgiftene søkje om at den andre
                 betaler sin del. Les meir om{" "}
@@ -93,7 +96,7 @@ const HvisDuErEnsligForsorgerNynorsk = () => (
                     særtilskot
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
     </Artikkel>
 );

--- a/src/artikler/hvis-du-er-gift/HvisDuErGiftBokmal.tsx
+++ b/src/artikler/hvis-du-er-gift/HvisDuErGiftBokmal.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import {andreMuligheterBrodsmulestiBokmal} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const HvisDuErGiftBokmal = () => (
     <Artikkel
@@ -13,19 +14,21 @@ const HvisDuErGiftBokmal = () => (
         foreldreside={andreMuligheterBrodsmulestiBokmal}
     >
         <Innholdstittel>Hvis du er gift</Innholdstittel>
-        <Normaltekst>
+
+        <Avsnitt>
             Hvis du er gift har du og ektefelle din gjensidig plikt til å
             forsørge hverandre. Det betyr at vi vurderer deres samlede økonomi
             når vi beregner økonomisk sosialhjelp.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Hvis du som ektefelle ikke blir forsørget av den du er gift med,
             selv om ektefellen din har inntekter, kan din selvstendige
             økonomiske situasjon bli lagt til grunn for å beregne økonomisk
             sosialhjelp i en periode. Eksempler hvor dette kan være aktuelt er
             hvis
-        </Normaltekst>
+        </Avsnitt>
+
         <div className="typo-normal">
             <ul>
                 <li>du oppholder deg på et krisesenter</li>
@@ -34,9 +37,9 @@ const HvisDuErGiftBokmal = () => (
                 <li>ektefellen din soner i fengsel</li>
             </ul>
         </div>
+
         <Undertittel>Ektefellebidrag</Undertittel>
-        <br />
-        <Normaltekst>
+        <Avsnitt>
             Hvis et ektepar flytter fra hverandre, blir separert eller skilt,
             kan den ene parten i enkelte tilfeller kreve underholdsbidrag fra
             den andre. For eksempel hvis hans/hennes mulighet til å forsørge seg
@@ -46,7 +49,7 @@ const HvisDuErGiftBokmal = () => (
                 ektefellebidrag
             </Lenke>
             .
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/hvis-du-er-gift/HvisDuErGiftEnglish.tsx
+++ b/src/artikler/hvis-du-er-gift/HvisDuErGiftEnglish.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import {andreMuligheterBrodsmulestiEngelsk} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const HvisDuErGiftEnglish = () => (
     <Artikkel
@@ -13,20 +14,19 @@ const HvisDuErGiftEnglish = () => (
         foreldreside={andreMuligheterBrodsmulestiEngelsk}
     >
         <Innholdstittel>If you are married</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             If you are married, you and your spouse have a mutual obligation to
             provide for each other. That means we will consider your collective
             financial situation when we assess your need for financial
             assistance.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             If your spouse does not provide for you, even if he or she has an
             income, your individual financial situation may be taken into
             account in the assessment of your needs for financial assistance for
             a limited time. Examples of circumstances where this would apply
             include
-        </Normaltekst>
+        </Avsnitt>
         <div className="typo-normal">
             <ul>
                 <li>if you are staying in a women’s crisis shelter</li>
@@ -36,8 +36,7 @@ const HvisDuErGiftEnglish = () => (
             </ul>
         </div>
         <Undertittel>Spousal support</Undertittel>
-        <br />
-        <Normaltekst>
+        <Avsnitt>
             If a married couple separate or become divorced, one spouse may,
             under certain circumstances, claim spousal support from the other
             spouse. This would, for example, include situations where he or she
@@ -47,7 +46,7 @@ const HvisDuErGiftEnglish = () => (
                 spousal support
             </Lenke>
             .
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/hvis-du-er-gift/HvisDuErGiftNynorsk.tsx
+++ b/src/artikler/hvis-du-er-gift/HvisDuErGiftNynorsk.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import {andreMuligheterBrodsmulestiNynorsk} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const HvisDuErGiftNynorsk = () => (
     <Artikkel
@@ -13,18 +14,20 @@ const HvisDuErGiftNynorsk = () => (
         foreldreside={andreMuligheterBrodsmulestiNynorsk}
     >
         <Innholdstittel>Dersom du er gift</Innholdstittel>
-        <Normaltekst>
+
+        <Avsnitt>
             Dersom du er gift har du og ektefellen din gjensidig plikt til å
             forsørgje kvarandre. Det betyr at vi vurderer dykkar samla økonomi
             når vi utreknar økonomisk sosialhjelp.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Dersom du som ektefelle ikkje blir forsørgja av den du er gift med,
             sjølv om ektefellen din har inntekter, kan din sjølvstendige
             økonomiske situasjon bli lagt til grunn for å utrekne økonomisk
             sosialhjelp i ein periode. Døme kor dette kan vere aktuelt er dersom
-        </Normaltekst>
+        </Avsnitt>
+
         <div className="typo-normal">
             <ul>
                 <li>du oppheld deg på eit krisesenter</li>
@@ -33,9 +36,10 @@ const HvisDuErGiftNynorsk = () => (
                 <li>ektefellen din sonar i fengsel</li>
             </ul>
         </div>
+
         <Undertittel>Ektefellebidrag</Undertittel>
-        <br />
-        <Normaltekst>
+
+        <Avsnitt>
             Om eit ektepar flyttar frå kvarandre, blir separert eller skild, kan
             den eine parten i enkelte tilfellet krevje underhaldsbidrag frå den
             andre. Til dømes dersom hans/hennes moglegheit til å forsørgje seg
@@ -45,7 +49,7 @@ const HvisDuErGiftNynorsk = () => (
                 ektefellebidrag
             </Lenke>
             .
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/hvis-du-har-barn/HvisDuHarBarnBokmal.tsx
+++ b/src/artikler/hvis-du-har-barn/HvisDuHarBarnBokmal.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import Lenke from "nav-frontend-lenker";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import {andreMuligheterBrodsmulestiBokmal} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const HvisDuHarBarnBokmal = () => (
     <Artikkel
@@ -14,84 +15,85 @@ const HvisDuHarBarnBokmal = () => (
         foreldreside={andreMuligheterBrodsmulestiBokmal}
     >
         <Innholdstittel>Hvis du har barn</Innholdstittel>
-        <Normaltekst>
+
+        <Avsnitt>
             Hvis du har barn er det egne plikter og ordninger som gjelder.
-        </Normaltekst>
-        <br />
+        </Avsnitt>
+
         <Ekspanderbartpanel tittel="Forsørgelsesplikt" border>
             <Undertittel tag="h3">Når du har barn</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Du har som forelder plikt til å forsørge dine mindreårige barn,
                 selv om de ikke bor sammen med deg. Hvis økonomien tilsier det,
                 kan du som forelder bli pålagt å forsørge barn over 18 år som
                 følger ordinær skolegang.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Barn over 18 år har rett til å bli vurdert selvstendig med
                 hensyn til beregning av økonomisk stønad.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Barn har ikke plikt til å forsørge foreldre eller søsken.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
+
             <Undertittel tag="h3">Når dere er samboere</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Foreldre i et samboerforhold med felles barn har plikt til å
                 forsørge barna etter økonomisk evne. Dette betyr at dere normalt
                 ikke kan søke om økonomisk sosialhjelp til å forsørge felles
                 barn hvis en av dere har tilstrekkelige inntekter til å forsørge
                 barna alene. I familier med særkullsbarn kan situasjonen være
                 slik at deler av familien blir vurdert for seg.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Hvis du ikke bor sammen med egne barn, skal utgifter til samvær
                 inngå i livsoppholdet. Stønad til samvær blir vurdert ut fra
                 samværets omfang.
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel
             tittel="Redusert betaling for barnehage og SFO"
             border
         >
-            <Normaltekst>
+            <Avsnitt>
                 Hvis du har lav inntekt, kan du søke kommunen om få redusert
                 utgiftene til barnehageplass.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Hvor mye du kan få redusert betalingen varierer fra kommune til
                 kommune. I noen kommuner kan du søke om helt fritak for
                 foreldrebetalingen.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Du kan også søke om redusert betaling for opphold i
                 skolefritidsordning (SFO) eller aktivitetsskole i enkelte
                 kommuner.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Disse tjenestene er organisert forskjellig i kommunene. Ta
                 kontakt med kommunen din, eller snakk med barnehagen om hvor du
                 skal henvende deg.
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Ferie og fritidstilbud" border>
-            <Normaltekst>
+            <Avsnitt>
                 Har du barn som trenger å være med på fritidsaktiviteter, men
                 har ikke råd på grunn av familiens økonomi? Kontakt NAV-kontoret
                 og sjekk mulighetene for støtte til ferie og fritidstilbud.
                 Under finner du også noen nyttige tips.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
+
             <Undertittel tag="h3">Opplevelseskort</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Opplevelseskortet gir barn og unge gratis adgang til kultur- og
                 fritidsaktiviteter. Kontingent til trening, svømmehall, kino og
                 lekeland er eksempler på aktiviteter. Tilbudene varierer fra
@@ -102,11 +104,11 @@ const HvisDuHarBarnBokmal = () => (
                 . Du skal vanligvis kontakte NAV-kontoret ditt, slik at de kan
                 vurdere situasjonen din. I noen kommuner skal du kontakte
                 barneverntjenesten, helsestasjonen eller andre instanser.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
+
             <Undertittel tag="h3">Ferie for alle</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Ferie for alle er et gratis tilbud til familier som trenger en
                 aktiv ferieopplevelse for hele familien. Tilbudet foregår i
                 skoleferiene og Røde Kors er arrangør. Ta kontakt med
@@ -116,11 +118,11 @@ const HvisDuHarBarnBokmal = () => (
                     Røde Kors
                 </Lenke>{" "}
                 for hvilke tilbud som finnes.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
+
             <Undertittel tag="h3">Feriesentralen</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Privatpersoner og forskjellige aktører legger inn tips om
                 aktiviteter og arrangementer på{" "}
                 <Lenke href="http://feriesentralen.no/">
@@ -130,7 +132,7 @@ const HvisDuHarBarnBokmal = () => (
                 arrangementer med mer. Du kan også legge inn dine aktivitets- og
                 ferieønsker, for eksempel låne eller leie en hytte eller
                 campingvogn.
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
     </Artikkel>
 );

--- a/src/artikler/hvis-du-har-barn/HvisDuHarBarnEnglish.tsx
+++ b/src/artikler/hvis-du-har-barn/HvisDuHarBarnEnglish.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import Lenke from "nav-frontend-lenker";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import {andreMuligheterBrodsmulestiEngelsk} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const HvisDuHarBarnEnglish = () => (
     <Artikkel
@@ -14,34 +15,34 @@ const HvisDuHarBarnEnglish = () => (
         foreldreside={andreMuligheterBrodsmulestiEngelsk}
     >
         <Innholdstittel>If you have children</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             If you have children, other obligations and arrangements apply.
-        </Normaltekst>
-        <br />
+        </Avsnitt>
+
         <Ekspanderbartpanel tittel="Obligation to provide" border>
             <Undertittel tag="h3">When you have children</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 As a parent, you have an obligation to provide for your children
                 as long as they are minors, even when they do not live with you.
                 If your financial situation permits it, you may, as a parent,
                 also be ordered to provide for children older than 18, provided
                 they are still enrolled in an ordinary education programme.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Children older than 18 have the right to have their situation
                 assessed on an individual basis in terms of social assistance.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Children do not have an obligation to provide for their parents
                 or siblings.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
+
             <Undertittel tag="h3">When you live together</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Parents who are cohabitants with joint children have an
                 obligation to provide for their children within the framework of
                 their financial situation. This means that you will normally not
@@ -50,54 +51,54 @@ const HvisDuHarBarnEnglish = () => (
                 for the children on their own. In families where one or both
                 parents have children from previous relationships, parts of the
                 family may be assessed separately.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 If you do not live with your children, expenses you incur in
                 connection with contact will be included in your subsistence
                 needs. Assistance for contact will be assessed on the basis of
                 the scope of the contact.
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel
             tittel="Reduction in kindergarten and SFO costs"
             border
         >
-            <Normaltekst>
+            <Avsnitt>
                 If your income is low, you may apply to the municipality to
                 reduce your kindergarten payments.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 How much your payment can be reduced will vary from municipality
                 to municipality. Some municipalities will accept applications to
                 be exempt from kindergarten payments.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 You may also apply for a reduction in payments for day care for
                 school-aged children (SFO) or after school care programmes (AKS)
                 in certain municipalities.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 These services vary from municipality to municipality. Contact
                 your municipality or talk to your kindergarten about whom to
                 contact.
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Holiday and laisure time activities" border>
-            <Normaltekst>
+            <Avsnitt>
                 Do you have children who need to participate in leisure time
                 activieis, but you cannot afford it given your family’s
                 financial situation? Contact your NAV office to learn more about
                 support for holiday and leisure time activities. There are also
                 some useful tips below.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
+
             <Undertittel tag="h3">Experience Card</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 The Experience Card gives children and youths free access to
                 cultural and leisure time activities. Training fees and swimming
                 pool, cinema and activity centre entrance are examples of
@@ -110,11 +111,11 @@ const HvisDuHarBarnEnglish = () => (
                 that they can assess your situation. In some municipalities, you
                 will instead be asked to contact child welfare services, the
                 health clinic or other bodies.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
+
             <Undertittel tag="h3">Holidays for all</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Holidays for all is a free service for families who need an
                 active holiday experience for the whole family. The service is
                 available in school holidays and is organized by the Red Cross.
@@ -125,13 +126,13 @@ const HvisDuHarBarnEnglish = () => (
                     the Red Cross website
                 </Lenke>{" "}
                 to read more about the services offered.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
+
             <Undertittel tag="h3">
                 Feriesentralen - a holiday central
             </Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Private individuals and various organizations post tips about
                 activities and events at{" "}
                 <Lenke href="http://feriesentralen.no/">
@@ -141,7 +142,7 @@ const HvisDuHarBarnEnglish = () => (
                 tickets to events, etc. You can also go there to post your
                 requests for activities or holiday wishes, such as wanting to
                 borrow or rent a cabin or caravan, etc.
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
     </Artikkel>
 );

--- a/src/artikler/hvis-du-har-barn/HvisDuHarBarnNynorsk.tsx
+++ b/src/artikler/hvis-du-har-barn/HvisDuHarBarnNynorsk.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import Lenke from "nav-frontend-lenker";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import {andreMuligheterBrodsmulestiNynorsk} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const HvisDuHarBarnNynorsk = () => (
     <Artikkel
@@ -14,84 +15,84 @@ const HvisDuHarBarnNynorsk = () => (
         foreldreside={andreMuligheterBrodsmulestiNynorsk}
     >
         <Innholdstittel>Dersom du har barn</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             Dersom du har barn er det eigne plikter og ordningar som gjelder.
-        </Normaltekst>
-        <br />
+        </Avsnitt>
+
         <Ekspanderbartpanel tittel="Forsørgingsplikt" border>
             <Undertittel tag="h3">Når du har barn</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Du har som forelder plikt til å forsørgje dine mindreårige barn,
                 sjølv om dei ikkje bur saman med deg. Dersom økonomien tilseier
                 det, kan du som forelder bli pålagd å forsørgje barn over 18 år
                 som følgjer ordinær skulegang.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Barn over 18 år har rett til å bli vurdert sjølvstendig med
                 omsyn til utrekning av økonomisk stønad.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Barn har ikkje plikt til å forsørgje foreldre eller søsken.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
+
             <Undertittel tag="h3">Når de er sambuarar</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Foreldre i eit sambuarforhold med felles barn har plikt til å
                 forsørgje barn etter økonomisk evne. Dette betyr at de normalt
                 ikkje kan søkje om økonomisk sosialhjelp til å forsørgje felles
                 barn om ein av dykk har tilstrekkelege inntekter til å forsørgje
                 barna alene. I familiar med særkullsbarn kan situasjonen vere
                 slik at deler av familien blir vurdert for seg.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Dersom du ikkje bur saman med eigne barn, skal utgifter til
                 samvær inngå i livsopphaldet. Stønad til samvær blir vurdert ut
                 frå omfanget på samværet.
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel
             tittel="Redusert betaling for barnehage og SFO"
             border
         >
-            <Normaltekst>
+            <Avsnitt>
                 Dersom du har låg inntekt, kan du søkje kommunen om få redusert
                 utgiftene til barnehageplass.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Kor mykje du kan få redusert betalinga varierer frå kommune til
                 kommune. I nokre kommunar kan du søkje om heilt fritak for
                 foreldrebetalinga.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Du kan òg søkje om redusert betaling for opphald i
                 skulefritidsordning (SFO) eller aktivitetsskule i enkelte
                 kommunar.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+
+            <Avsnitt>
                 Tenestene er organisert forskjellig i kommunane. Ta kontakt med
                 kommunen din, eller snakk med barnehagen om kor du skal ta
                 kontakt.
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
         <Ekspanderbartpanel tittel="Ferie og fritidstilbod" border>
-            <Normaltekst>
+            <Avsnitt>
                 Har du barn som treng å vere med på fritidsaktivitetar, men
                 ikkje råd på grunn av familiens økonomi? Kontakt NAV-kontoret og
                 sjekk moglegheitene for støtte til ferie og fritidstilbod. Under
                 finn du òg nokre nyttige tips.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
+
             <Undertittel tag="h3">Opplevingskort</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Opplevingskortet gir barn og unge gratis tilgang til kultur- og
                 fritidsaktivitetar. Kontingent til trening, symjehall, kino og
                 leikeland er døme på aktivitetar. Tilboda varierer frå kommune
@@ -102,11 +103,11 @@ const HvisDuHarBarnNynorsk = () => (
                 . Du skal vanlegvis kontakte NAV-kontoret ditt, slik at de kan
                 vurdere situasjonen din. I nokre kommunar skal du kontakte
                 barnevernstenesta, helsestasjonen eller andre instansar.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
+
             <Undertittel tag="h3">Ferie for alle</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Ferie for alle er eit gratis tilbod til familiar som treng ein
                 aktiv ferieoppleving for heile familien. Tilbodet føregår i
                 skuleferiane og Røde Kors er arrangør. Ta kontakt med
@@ -117,11 +118,11 @@ const HvisDuHarBarnNynorsk = () => (
                     Røde Kors
                 </Lenke>{" "}
                 for kva tilbod som finst.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
+
             <Undertittel tag="h3">Feriesentralen</Undertittel>
-            <br />
-            <Normaltekst>
+
+            <Avsnitt>
                 Privatpersonar og forskjellige aktørar legg inn tips om
                 aktivitetar og arrangement på{" "}
                 <Lenke href="http://feriesentralen.no/">
@@ -131,7 +132,7 @@ const HvisDuHarBarnNynorsk = () => (
                 arrangement med meir. Du kan òg leggje inn dine aktivitets- og
                 ferieønskje, til dømes låne eller leie en hytte eller
                 campingvogn.
-            </Normaltekst>
+            </Avsnitt>
         </Ekspanderbartpanel>
     </Artikkel>
 );

--- a/src/artikler/hvis-du-har-samboer/HvisDuHarSamboerBokmal.tsx
+++ b/src/artikler/hvis-du-har-samboer/HvisDuHarSamboerBokmal.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import {andreMuligheterBrodsmulestiBokmal} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const HvisDuHarSamboerBokmal = () => (
     <Artikkel
@@ -12,26 +13,26 @@ const HvisDuHarSamboerBokmal = () => (
         foreldreside={andreMuligheterBrodsmulestiBokmal}
     >
         <Innholdstittel>Hvis du er samboer</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             Samboere har ikke gjensidig plikt til å forsørge hverandre. Med
             mindre dere har barn betyr det at økonomien i utgangspunktet ikke
             blir vurdert samlet når vi beregner økonomisk sosialhjelp.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Foreldre i et samboerforhold med felles barn har plikt til å
             forsørge barna etter økonomisk evne. Dette betyr at dere normalt
             ikke kan søke om økonomisk sosialhjelp til å forsørge felles barn
             hvis en av dere har tilstrekkelige inntekter til å forsørge barna
             alene. I familier med særkullsbarn kan situasjonen være slik at
             deler av familien blir vurdert for seg.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Hvis du ikke bor sammen med egne barn, skal utgifter til samvær
             inngå i livsoppholdet. Stønad til samvær blir vurdert ut fra
             samværets omfang.
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/hvis-du-har-samboer/HvisDuHarSamboerEnglish.tsx
+++ b/src/artikler/hvis-du-har-samboer/HvisDuHarSamboerEnglish.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import {andreMuligheterBrodsmulestiEngelsk} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const HvisDuHarSamboerEnglish = () => (
     <Artikkel
@@ -12,14 +13,14 @@ const HvisDuHarSamboerEnglish = () => (
         foreldreside={andreMuligheterBrodsmulestiEngelsk}
     >
         <Innholdstittel>If you are a cohabitant</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             Cohabitants do not have a mutual obligation to provide for each
             other. Unless you have children together, this means that your
             collective financial situation will not be taken into account when
             we assess your need for social assistance.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Parents who are cohabitants with joint children have an obligation
             to provide for their children within the framework of their
             financial situation. This means that you will normally not qualify
@@ -28,14 +29,14 @@ const HvisDuHarSamboerEnglish = () => (
             their own. In families where one or both parents have children from
             previous relationships, parts of the family may be assessed
             separately.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             If you do not live with your children, expenses you incur in
             connection with contact will be included in your subsistence needs.
             Assistance for contact will be assessed on the basis of the scope of
             the contact.
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/hvis-du-har-samboer/HvisDuHarSamboerNynorsk.tsx
+++ b/src/artikler/hvis-du-har-samboer/HvisDuHarSamboerNynorsk.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import {andreMuligheterBrodsmulestiNynorsk} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const HvisDuHarSamboerNynorsk = () => (
     <Artikkel
@@ -12,26 +13,26 @@ const HvisDuHarSamboerNynorsk = () => (
         foreldreside={andreMuligheterBrodsmulestiNynorsk}
     >
         <Innholdstittel>Dersom du er sambuar</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             Sambuarar har ikkje gjensidig plikt til å forsørgje kvarandre. Med
             mindre dei har barn betyr det at økonomien i utgangspunktet ikkje
             blir vurdert samla når vi utreknar økonomisk sosialhjelp.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Foreldre i eit sambuarforhold med felles barn har plikt til å
             forsørgje barna etter økonomisk evne. Dette betyr at ein normalt
             ikkje kan søkje om økonomisk sosialhjelp til å forsørgje felles
             barn, dersom ein av dykk har tilstrekkelege inntekter til å
             forsørgje barna aleine. I familiar med særkullsbarn kan situasjonen
             vere slik at deler av familien blir vurdert for seg.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Dersom du ikkje bur saman med eigne barn, skal utgifter til samvær
             inngå i livsoppholdet. Stønad til samvær blir vurdert ut frå
             omfanget på samværet.
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/klage/KlageBokmal.tsx
+++ b/src/artikler/klage/KlageBokmal.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const KlageBokmal: React.FC = () => (
     <Artikkel
@@ -10,28 +11,28 @@ const KlageBokmal: React.FC = () => (
         illustrasjon={<Veiskilft className="illustrasjon" />}
     >
         <Innholdstittel>Klage på vedtak om sosiale tjenester</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             Hvis du har fått et vedtak fra oss som du mener er feil, kan du
             klage.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>Slik klager du</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             Du skal sende klagen til NAV-kontoret som har gjort vedtaket.
             Klagefristen er tre uker fra du mottar vedtaket.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>Trenger du hjelp til å klage?</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             NAV-kontoret ditt kan hjelpe deg hvis du trenger hjelp til å skrive
             klagen. Da må du avtale en time på NAV-kontoret. Hvis du ønsker å ha
             med deg en person du har tillit til, har du rett til det.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Du kan også bruke advokat eller gi fullmakt til en person som klager
             på dine vegne.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>Hva skal klagen inneholde?</Undertittel>
-        <Normaltekst>
+        <div className="typo-normal">
             <ul>
                 <li>
                     Hvilket vedtak klagen gjelder. Du kan eventuelt legge ved
@@ -43,34 +44,32 @@ const KlageBokmal: React.FC = () => (
                 </li>
                 <li>Signatur</li>
             </ul>
-        </Normaltekst>
-        <Normaltekst>
-            Du kan legge ved dokumentasjon til klagen din.
-        </Normaltekst>
+        </div>
+        <Avsnitt>Du kan legge ved dokumentasjon til klagen din.</Avsnitt>
         <Undertittel>Hva skjer når du klager?</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             Når du klager vil NAV-kontoret som har gjort vedtaket vurdere saken
             din på nytt. Saksbehandlingstiden varierer fra kommune til kommune.
             Hvis det går mer enn én måned, skal du få et foreløpig svar. Hvis du
             får medhold i klagen din, får du et nytt vedtak.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Hvis du ikke får medhold, blir klagen sendt videre til Fylkesmannen
             som vurderer saken din på nytt. Du får informasjon om
             saksbehandlingstid hos Fylkesmannen og hva som skjer videre.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Når Fylkesmannen har avgjort saken din, får du et nytt vedtak.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>Du kan få dekket utgifter</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             Hvis du får medhold i klagen, kan du ha rett til å få dekket
             utgifter som har vært nødvendige for å få endret vedtaket. Et
             eksempel er utgifter til advokat. Da kan du sende krav om å få
             dekket sakskostnader til NAV-kontoret som har omgjort vedtaket.
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/klage/KlageEnglish.tsx
+++ b/src/artikler/klage/KlageEnglish.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const KlageEnglish: React.FC = () => (
     <Artikkel
@@ -10,29 +11,29 @@ const KlageEnglish: React.FC = () => (
         illustrasjon={<Veiskilft className="illustrasjon" />}
     >
         <Innholdstittel>Appeal for decisions on social services</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             You may lodge an appeal if you have received a decision from us that
             you believe is wrong.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>How to appeal?</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             Send the appeal to the NAV office that made the decision. The term
             of appeal is 3 weeks from the date on which you receive notice of
             the decision.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>Who can help you lodge an appeal?</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             Your NAV office can assist you if you need help writing your appeal.
             In that case, you will have to make an appointment with the NAV
             office. You are entitled to be accompanied by a person you trust.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             You can also enlist a lawyer or authorise someone to handle the
             appeals process on your behalf.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>What should the appeal contain?</Undertittel>
-        <Normaltekst>
+        <div className="typo-normal">
             <ul>
                 <li>
                     Which decision the appeal applies to. You can optionally
@@ -44,34 +45,34 @@ const KlageEnglish: React.FC = () => (
                 </li>
                 <li>Signature</li>
             </ul>
-        </Normaltekst>
-        <Normaltekst>You may submit necessary documentation.</Normaltekst>
+        </div>
+        <Avsnitt>You may submit necessary documentation. </Avsnitt>
         <Undertittel>What happens when you appeal?</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             When you appeal, the NAV unit that wrote the original decision will
             reassess your case. Processing times vary from municipality to
             municipality. If more than a month goes by, you are entitled to a
             preliminary response. If your appeal is successful, NAV will issue a
             new decision that you will receive in the post.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             If the decision remains unchanged, your appeal is forwarded to
             Fylkemannen who will make a final decision. You will receive a
             letter when the case is sent to Fylkesmannen. The letter will
             explain the further process.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             You will receive a new decision when Fylkesmannen decides your case.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>You can get your expenses covered</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             If your appeal is successful, you may be entitled to reimbursement
             of expenses that were necessary to have the decision overturned,
             such as legal fees. Submit your claim for reimbursement of costs to
             the NAV office that set aside the original decision.
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/klage/KlageNynorsk.tsx
+++ b/src/artikler/klage/KlageNynorsk.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const KlageNynorsk: React.FC = () => (
     <Artikkel
@@ -10,27 +11,27 @@ const KlageNynorsk: React.FC = () => (
         illustrasjon={<Veiskilft className="illustrasjon" />}
     >
         <Innholdstittel>Klage på vedtak om sosiale tenester</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             Har du fått eit vedtak frå oss som du meiner er feil, kan du klage.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>Slik klager du</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             Du skal sende klagen til NAV-kontoret som har gjort vedtaket.
             Klagefristen er tre veker frå du har fått vedtaket.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>Trenger du hjelp til å klage?</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             NAV-kontoret ditt kan hjelpe deg dersom du treng hjelp til å skrive
             klagen. Då må du avtale ein time på NAV-kontoret. Du har rett til å
             ha med deg ein person du har tillit til om du ønskjer det.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Du kan òg bruke advokat eller gi fullmakt til ein person som klager
             på vegne av deg.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>Kva skal klagen innehalde?</Undertittel>
-        <Normaltekst>
+        <div className="typo-normal">
             <ul>
                 <li>
                     Kva vedtak klagen gjeld. Du kan eventuelt legge ved vedtaket
@@ -42,35 +43,33 @@ const KlageNynorsk: React.FC = () => (
                 </li>
                 <li>Signatur</li>
             </ul>
-        </Normaltekst>
-        <Normaltekst>
-            Du kan legge ved dokumentasjon til klagen din.
-        </Normaltekst>
+        </div>
+        <Avsnitt>Du kan legge ved dokumentasjon til klagen din.</Avsnitt>
         <Undertittel>Kva skjer når du klagar?</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             NAV-kontoret som har gjort vedtaket skal vurdere saka di på nytt.
             Saksbehandlingstida varierer frå kommune til kommune. Dersom det går
             meir enn éin måned, skal du få eit foreløpig svar. Dersom du får
             medhald i klagen din, får du eit nytt vedtak.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Dersom du ikkje får medhald, blir klagen sendt vidare til
             Fylkesmannen som vurderer saka di på nytt. Du får informasjon om
             saksbehandlingstid hjå Fylkesmannen og kva som skjer vidare.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Når Fylkesmannen har behandla saka di, får du eit nytt vedtak.{" "}
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>Du kan få dekt utgifter</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             Dersom du får medhald i klagen, kan du ha rett til å få dekt
             utgifter som har vore nødvendige for å få endra vedtaket. Eit
             eksempel er utgifter til advokat. For å få dette vurdert kan du
             sende eit skriftleg krav om å få dekka sakskostnader til
             NAV-kontoret som har gjort om vedtaket.
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/kontakte-veileder/KontakteVeilederBokmal.tsx
+++ b/src/artikler/kontakte-veileder/KontakteVeilederBokmal.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 import Artikkel from "../Artikkel";
 import "../artikkel.less";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const KontakteVeilederBokmal: React.FC = () => {
     return (
@@ -10,28 +11,24 @@ const KontakteVeilederBokmal: React.FC = () => {
             <Innholdstittel>
                 Hvordan kontakter du veilederen din?
             </Innholdstittel>
-            <Normaltekst>
-                Hvis du trenger å snakke med noen om situasjonen din
-                eller saken din, kan du
-                {" "}
+            <Avsnitt>
+                Hvis du trenger å snakke med noen om situasjonen din eller saken
+                din, kan du{" "}
                 <Lenke
                     href={
                         "https://www.nav.no/no/nav-og-samfunn/kontakt-nav/kontakt-nav-pa-telefon2"
-                    }>
+                    }
+                >
                     kontakte oss på telefon
-                </Lenke>
-                {" "}
-                eller møte opp på NAV-kontoret der du bor for å avtale
-                et møte. Les mer om
-                {" "}
+                </Lenke>{" "}
+                eller møte opp på NAV-kontoret der du bor for å avtale et møte.
+                Les mer om{" "}
                 <Lenke
-                    href={
-                        "https://www.nav.no/sosialhjelp/slik-foregar-et-mote"
-                    }>
+                    href={"https://www.nav.no/sosialhjelp/slik-foregar-et-mote"}
+                >
                     hvordan et møte foregår med oss.
                 </Lenke>
-            </Normaltekst>
-            <br />
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/kontakte-veileder/KontakteVeilederEngelsk.tsx
+++ b/src/artikler/kontakte-veileder/KontakteVeilederEngelsk.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 import Artikkel from "../Artikkel";
 import "../artikkel.less";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const KontakteVeilederEngelsk: React.FC = () => {
     return (
@@ -10,28 +11,24 @@ const KontakteVeilederEngelsk: React.FC = () => {
             <Innholdstittel>
                 Hvordan kontakter du veilederen din?
             </Innholdstittel>
-            <Normaltekst>
-                Hvis du trenger å snakke med noen om situasjonen din
-                eller saken din, kan du
-                {" "}
+            <Avsnitt>
+                Hvis du trenger å snakke med noen om situasjonen din eller saken
+                din, kan du{" "}
                 <Lenke
                     href={
                         "https://www.nav.no/no/nav-og-samfunn/kontakt-nav/kontakt-nav-pa-telefon2"
-                    }>
+                    }
+                >
                     kontakte oss på telefon
-                </Lenke>
-                {" "}
-                eller møte opp på NAV-kontoret der du bor for å avtale
-                et møte. Les mer om
-                {" "}
+                </Lenke>{" "}
+                eller møte opp på NAV-kontoret der du bor for å avtale et møte.
+                Les mer om{" "}
                 <Lenke
-                    href={
-                        "https://www.nav.no/sosialhjelp/slik-foregar-et-mote"
-                    }>
+                    href={"https://www.nav.no/sosialhjelp/slik-foregar-et-mote"}
+                >
                     hvordan et møte foregår med oss.
                 </Lenke>
-            </Normaltekst>
-            <br />
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/kontakte-veileder/KontakteVeilederNynorsk.tsx
+++ b/src/artikler/kontakte-veileder/KontakteVeilederNynorsk.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 import Artikkel from "../Artikkel";
 import "../artikkel.less";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const KontakteVeilederNynorsk: React.FC = () => {
     return (
@@ -10,28 +11,24 @@ const KontakteVeilederNynorsk: React.FC = () => {
             <Innholdstittel>
                 Hvordan kontakter du veilederen din?
             </Innholdstittel>
-            <Normaltekst>
-                Hvis du trenger å snakke med noen om situasjonen din
-                eller saken din, kan du
-                {" "}
+            <Avsnitt>
+                Hvis du trenger å snakke med noen om situasjonen din eller saken
+                din, kan du{" "}
                 <Lenke
                     href={
                         "https://www.nav.no/no/nav-og-samfunn/kontakt-nav/kontakt-nav-pa-telefon2"
-                    }>
+                    }
+                >
                     kontakte oss på telefon
-                </Lenke>
-                {" "}
-                eller møte opp på NAV-kontoret der du bor for å avtale
-                et møte. Les mer om
-                {" "}
+                </Lenke>{" "}
+                eller møte opp på NAV-kontoret der du bor for å avtale et møte.
+                Les mer om{" "}
                 <Lenke
-                    href={
-                        "https://www.nav.no/sosialhjelp/slik-foregar-et-mote"
-                    }>
+                    href={"https://www.nav.no/sosialhjelp/slik-foregar-et-mote"}
+                >
                     hvordan et møte foregår med oss.
                 </Lenke>
-            </Normaltekst>
-            <br />
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/korona/KoronaBokmal.tsx
+++ b/src/artikler/korona/KoronaBokmal.tsx
@@ -1,25 +1,26 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 import Artikkel from "../Artikkel";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const KoronaBokmal = () => (
     <Artikkel tittel="Koronavirus - flere kan ha rett til økonomisk sosialhjelp">
         <Innholdstittel>
             Koronavirus - flere kan ha rett til økonomisk sosialhjelp
         </Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             Pandemisituasjonen kan føre til at flere personer kan ha rett til
             økonomisk sosialhjelp.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Hvis du ikke har andre muligheter til å forsørge deg selv som for
             eksempel gjennom jobb, andre inntekter eller egne midler, kan du ha
             rett til økonomisk sosialhjelp.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Alle har rett til å{" "}
             <Lenke href="./slik-soker-du">søke om økonomisk sosialhjelp</Lenke>{" "}
             og få en individuell vurdering av søknaden sin. Stengte barnehager
@@ -28,15 +29,14 @@ const KoronaBokmal = () => (
             enkelte. Ved søknad om økonomisk sosialhjelp, vil NAV-kontoret
             vurdere om du har ekstrautgifter som vi bør ta hensyn til. Vi legger
             særlig vekt på barn og unges behov.
-        </Normaltekst>
+        </Avsnitt>
 
         <Undertittel>Har du økonomiske bekymringer?</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             I denne korte filmen får du som har økonomiske bekymringer og{" "}
             midlertidige betalingsproblemer nyttige råd og tips.
-        </Normaltekst>
+        </Avsnitt>
 
-        <br />
         <div style={{padding: "56.25% 0 0 0", position: "relative"}}>
             <iframe
                 title={"Økonomiske bekymringer"}
@@ -56,52 +56,52 @@ const KoronaBokmal = () => (
 
         <Undertittel>Hva med vilkår om aktivitet?</Undertittel>
 
-        <Normaltekst>
+        <Avsnitt>
             Det skal ikke bli stilt vilkår og krav til deg som du ikke har
             mulighet til å følge opp på grunn av koronaviruset og hensynet til
             smittevern.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Hvis du mottar økonomisk sosialhjelp og det allerede er stilt vilkår
             om aktivitet, så skal ikke manglende gjennomført aktivitet føre til
             reduksjon av stønad eller andre konsekvenser for deg.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             Selv om det ikke stilles vilkår om aktivitet, så skal NAV-kontoret
             likevel gi deg råd og veiledning. Oppfølgingen kan skje digitalt
             eller over telefon.
-        </Normaltekst>
+        </Avsnitt>
 
-        <Undertittel>Selvstendig næringsdrivende, frilanser eller permittert?</Undertittel>
+        <Undertittel>
+            Selvstendig næringsdrivende, frilanser eller permittert?
+        </Undertittel>
 
-        <Normaltekst>
-            Myndighetene har vedtatt nye ordninger for inntektssikring. Hvis
-            du har mistet inntekt som følge av koronapandemien bør du sjekke
-            hvilke rettigheter du har. For deg som søker om dagpenger, så er
-            det også mulig å søke om forskudd på dagpengene. Les om
-            {" "}
+        <Avsnitt>
+            Myndighetene har vedtatt nye ordninger for inntektssikring. Hvis du
+            har mistet inntekt som følge av koronapandemien bør du sjekke hvilke
+            rettigheter du har. For deg som søker om dagpenger, så er det også
+            mulig å søke om forskudd på dagpengene. Les om{" "}
             <Lenke href="https://www.nav.no/person/koronaveiviser/">
                 Koronaviruset - hva gjelder i min situasjon?
-            </Lenke>
-            {" "}
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+            </Lenke>{" "}
+        </Avsnitt>
+
+        <Avsnitt>
             Hvis du ikke har andre muligheter til å forsørge deg selv, kan du ha
             rett til økonomisk sosialhjelp.
-        </Normaltekst>
+        </Avsnitt>
 
         <Undertittel>Koronaviruset- hva gjelder i din situasjon?</Undertittel>
 
-        <Normaltekst>
+        <Avsnitt>
             Du finner oppdatert informasjon i forbindelse med koronaviruset og
             hvordan du kommer i kontakt med oss nå under{" "}
             <Lenke href="https://www.nav.no/person/koronaveiviser/">
                 Koronaviruset - hva gjelder i min situasjon?
             </Lenke>
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/krav-til-deg/KravTilDegBokmal.tsx
+++ b/src/artikler/krav-til-deg/KravTilDegBokmal.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const KravTilDegBokmal: React.FC = () => (
     <Artikkel
@@ -10,15 +11,15 @@ const KravTilDegBokmal: React.FC = () => (
         illustrasjon={<Veiskilft className="illustrasjon" />}
     >
         <Innholdstittel>Krav om aktivitet</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             NAV kan stille vilkår om at du skal redusere utgifter, øke inntekter
             og delta i aktiviteter når du mottar økonomisk sosialhjelp.
-        </Normaltekst>
-        <br />
-        <Normaltekst>Målet er at du skal kunne forsørge deg selv.</Normaltekst>
-        <br />
-        <Normaltekst>NAV kan også stille vilkår om at du</Normaltekst>
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>Målet er at du skal kunne forsørge deg selv.</Avsnitt>
+
+        <Avsnitt>NAV kan også stille vilkår om at du</Avsnitt>
+        <div className="typo-normal">
             <ul>
                 <li>møter til veiledningssamtaler</li>
                 <li>søker på relevante jobber</li>
@@ -28,19 +29,19 @@ const KravTilDegBokmal: React.FC = () => (
                 </li>
                 <li>deltar i utdannings- og opplæringstiltak</li>
             </ul>
-        </Normaltekst>
+        </div>
         <Undertittel>For deg under 30</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             Hvis du er under 30 år, vil NAV stille krav om at du deltar i
             aktivitet når du mottar økonomisk sosialhjelp. Målet er å hjelpe deg
             til å komme i arbeid eller utdanning slik at du kan forsørge deg
             selv med egen inntekt.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>Hvis du ikke oppfyller vilkårene</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             Hvis du ikke oppfyller vilkårene som du har avtalt med NAV, kan det
             få konsekvenser for stønaden din.
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/krav-til-deg/KravTilDegEnglish.tsx
+++ b/src/artikler/krav-til-deg/KravTilDegEnglish.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const KravTilDegEnglishl: React.FC = () => (
     <Artikkel
@@ -10,18 +11,18 @@ const KravTilDegEnglishl: React.FC = () => (
         illustrasjon={<Veiskilft className="illustrasjon" />}
     >
         <Innholdstittel>Activity conditions</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             NAV may require you to reduce your expenses, increase your income
             and participate in activities in order to qualify for social
             assistance.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>
             The goal is for you to become able to provide for yourself.
-        </Normaltekst>
-        <br />
-        <Normaltekst>NAV may also require that you</Normaltekst>
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>NAV may also require that you</Avsnitt>
+        <div className="typo-normal">
             <ul>
                 <li>attend counselling interviews</li>
                 <li>apply to relevant jobs</li>
@@ -31,19 +32,19 @@ const KravTilDegEnglishl: React.FC = () => (
                 </li>
                 <li>participate in education and training programmes</li>
             </ul>
-        </Normaltekst>
+        </div>
         <Undertittel>For applicants under the age of 30</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             If you are under 30 years old, NAV will require you to participate
             in certain activities in order to qualify for social assistance. The
             goal is to help you find employment or start an education, so that
             you will be able to provide for yourself with your own income.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>If you fail to meet the requirements</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             If you fail to meet the requirements you agreed to with NAV, it may
             affect your payments.
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/krav-til-deg/KravTilDegNynorsk.tsx
+++ b/src/artikler/krav-til-deg/KravTilDegNynorsk.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const KravTilDegNynorsk: React.FC = () => (
     <Artikkel
@@ -10,17 +11,15 @@ const KravTilDegNynorsk: React.FC = () => (
         illustrasjon={<Veiskilft className="illustrasjon" />}
     >
         <Innholdstittel>Krav om aktivitet</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             NAV kan stille vilkår om at du skal redusere utgifter, auke
             inntekter og delta i aktivitetar når du får økonomisk sosialhjelp.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
-            Målet er at du skal kunne forsørgje deg sjølv.
-        </Normaltekst>
-        <br />
-        <Normaltekst>NAV kan òg stille vilkår om at du</Normaltekst>
-        <Normaltekst>
+        </Avsnitt>
+
+        <Avsnitt>Målet er at du skal kunne forsørgje deg sjølv.</Avsnitt>
+
+        <Avsnitt>NAV kan òg stille vilkår om at du</Avsnitt>
+        <div className="typo-normal">
             <ul>
                 <li>møter til rettleiingssamtalar</li>
                 <li>søkjer på relevante jobbar</li>
@@ -30,19 +29,19 @@ const KravTilDegNynorsk: React.FC = () => (
                 </li>
                 <li>deltek i utdannings- og opplæringstiltak</li>
             </ul>
-        </Normaltekst>
+        </div>
         <Undertittel>For deg under 30</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             Dersom du er under 30 år, vil NAV stille krav om at du deltek i
             aktivitet når du får økonomisk sosialhjelp. Målet er å hjelpe deg
             til å komme i arbeid eller utdanning slik at du kan forsørgje deg
             sjølv med eigen inntekt.
-        </Normaltekst>
+        </Avsnitt>
         <Undertittel>Der du ikkje oppfyller vilkåra</Undertittel>
-        <Normaltekst>
+        <Avsnitt>
             Dersom du ikkje oppfyller vilkåra som du har avtalt med NAV, kan det
             få konsekvensar for stønaden din.
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/nodsituasjon/NodistuasjonBokmal.tsx
+++ b/src/artikler/nodsituasjon/NodistuasjonBokmal.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import Lenke from "nav-frontend-lenker";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const NodsituasjonBokmal = () => (
     <Artikkel
@@ -11,15 +12,14 @@ const NodsituasjonBokmal = () => (
         illustrasjon={<Veiskilft className="illustrasjon" />}
     >
         <Innholdstittel>Hva gjør du i en nødssituasjon?</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             Hvis du ikke har mulighet til å skaffe egne midler til det aller
             nødvendigste, kan du{" "}
             <Lenke href="./slik-soker-du">søke om økonomisk sosialhjelp</Lenke>{" "}
             i den kommunen du oppholder deg i. Sjekk om du kan{" "}
             <Lenke href="./slik-soker-du">søke digitalt</Lenke> i din kommune.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             Du må du være tilgjengelig på telefon etter at du har sendt inn
             søknaden. Ofte vil noen fra NAV-kontoret kontakte deg for å kunne
             vurdere situasjonen din. Hvis du trenger å snakke med noen kan du
@@ -28,21 +28,18 @@ const NodsituasjonBokmal = () => (
                 kontakte oss på telefon
             </Lenke>
             .
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             Hjelp i en nødssituasjon skal dekke helt nødvendige utgifter for en
             kort periode. Eksempler er stønad til mat, hygieneartikler og
             reiseutgifter. Regninger som må betales for å hindre at nødvendige
             tjenester som strøm eller lignende blir stengt, kan også bli dekket
             i en nødssituasjon.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             Hvorfor du har kommet i denne situasjonen er uten betydning.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             Du kan også søke om hjelp til å finne et{" "}
             <Lenke href="https://www.nav.no/no/Person/Flere+tema/Sosiale+tjenester/bolig/midlertidig-botilbud">
                 midlertidig botilbud
@@ -56,12 +53,11 @@ const NodsituasjonBokmal = () => (
                 kontakte oss på telefon
             </Lenke>
             .
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             Du må bidra til å gi opplysninger om saken din på en best mulig
             måte, slik at NAV-kontoret raskt kan behandle søknaden din.
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/nodsituasjon/NodistuasjonEnglish.tsx
+++ b/src/artikler/nodsituasjon/NodistuasjonEnglish.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import Lenke from "nav-frontend-lenker";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const NodsituasjonEnglish = () => (
     <Artikkel
@@ -11,16 +12,15 @@ const NodsituasjonEnglish = () => (
         illustrasjon={<Veiskilft className="illustrasjon" />}
     >
         <Innholdstittel>When you are in an emergency</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             If you are unable to find the means to pay for essentials, you can
             apply for{" "}
             <Lenke href="./slik-soker-du?lang=en">financial assistance</Lenke> .
             Check if you can{" "}
             <Lenke href="./slik-soker-du?lang=en">apply digitally</Lenke> in
             your municipality.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             You should be available by phone after submitting your application.
             Someone from the NAV office will contact you to assess your
             situation. If you need to talk to someone you can also{" "}
@@ -28,21 +28,18 @@ const NodsituasjonEnglish = () => (
                 contact us by phone
             </Lenke>
             .
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             Emergency financial assistance covers bare essential expenses for a
             short period. Examples include food, hygiene items and travel
             expenses. Bills that must be paid to prevent necessary services such
             as electricity from being cut off may also be covered in an
             emergency.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             It does not matter why you have ended up in this situation.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             NAV will help you find{" "}
             <Lenke href="https://www.nav.no/en/home/relatert-informasjon/temporary-accommodation-emergency">
                 temporary accommodation
@@ -57,12 +54,11 @@ const NodsituasjonEnglish = () => (
                 contact us by phone
             </Lenke>
             .
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             NAV will be able to process your application more efficiently if you
             provide the best possible information about your situation.
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/nodsituasjon/NodistuasjonNynorsk.tsx
+++ b/src/artikler/nodsituasjon/NodistuasjonNynorsk.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 
 import Artikkel from "../Artikkel";
 import Veiskilft from "../../komponenter/bilder/Veiskilt";
 import Lenke from "nav-frontend-lenker";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const NodsituasjonNynorsk = () => (
     <Artikkel
@@ -11,7 +12,7 @@ const NodsituasjonNynorsk = () => (
         illustrasjon={<Veiskilft className="illustrasjon" />}
     >
         <Innholdstittel>Når du er i ein nødssituasjon</Innholdstittel>
-        <Normaltekst>
+        <Avsnitt>
             Dersom du ikkje har moglegheit til å skaffe eigne midlar til det
             aller mest nødvendige, kan du{" "}
             <Lenke href="./slik-soker-du?lang=nn">
@@ -20,9 +21,8 @@ const NodsituasjonNynorsk = () => (
             i kommunen du oppheld deg. Sjekk om du kan{" "}
             <Lenke href="./slik-soker-du?lang=nn">søkje digitalt</Lenke> i din
             kommune.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             Du må vere tilgjengeleg på telefon etter at du har sendt inn
             søknaden. Ofte vil nokon frå NAV-kontoret kontakte deg for å kunne
             vurdere situasjonen din. Dersom du treng å snakke med nokon kan du
@@ -31,22 +31,19 @@ const NodsituasjonNynorsk = () => (
                 kontakte oss på telefon
             </Lenke>
             .
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             Hjelp i ein nødssituasjon skal dekkje heilt nødvendige utgifter for
             ein kort periode. Døme er stønad til mat, hygieneartiklar og
             reiseutgifter. Rekningar som må bli betalt for å hindre at
             nødvendige tenester som straum eller liknande blir stengt, kan òg
             bli dekt i ein nødssituasjon.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             Kvifor du har kome i denne situasjonen er ikkje relevant for
             søknaden.
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             NAV skal òg hjelpe deg med å finne eit{" "}
             <Lenke href="https://www.nav.no/no/Person/Flere+tema/Sosiale+tjenester/bolig/midlertidig-botilbud">
                 midlertidig butilbod
@@ -61,12 +58,11 @@ const NodsituasjonNynorsk = () => (
                 kontakte oss på telefon
             </Lenke>
             .
-        </Normaltekst>
-        <br />
-        <Normaltekst>
+        </Avsnitt>
+        <Avsnitt>
             Du må bidra til å gi opplysningar om saka di på ein best mogleg
             måte, slik at NAV-kontoret raskt kan behandle søknaden din.
-        </Normaltekst>
+        </Avsnitt>
     </Artikkel>
 );
 

--- a/src/artikler/slik-foregar-et-mote/SlikForegatEtMoteBokmal.tsx
+++ b/src/artikler/slik-foregar-et-mote/SlikForegatEtMoteBokmal.tsx
@@ -1,15 +1,11 @@
 import * as React from "react";
-import {
-    Ingress,
-    Innholdstittel,
-    Normaltekst,
-    Undertittel,
-} from "nav-frontend-typografi";
+import {Ingress, Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Artikkel from "../Artikkel";
 import Veiskilt from "../../komponenter/bilder/Veiskilt";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import Lenke from "nav-frontend-lenker";
 import {andreMuligheterBrodsmulestiBokmal} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const SlikForegatEtMoteBokmal: React.FC = () => {
     return (
@@ -25,22 +21,16 @@ const SlikForegatEtMoteBokmal: React.FC = () => {
                 NAV-kontoret ditt og avtale et møte.
             </Ingress>
 
-            <br />
-
-            <Normaltekst>
+            <Avsnitt>
                 Det kan hende du er usikker før det første møtet hos NAV, og
                 lurer på hvor mye du må fortelle om situasjonen din. Hvis du
                 ønsker det, kan du ta med deg en person du har tillit til.
-            </Normaltekst>
+            </Avsnitt>
 
-            <br />
-
-            <Normaltekst>
+            <Avsnitt>
                 I møtet vil vi stille deg noen spørsmål for å finne ut hvilke
                 behov du har.
-            </Normaltekst>
-
-            <br />
+            </Avsnitt>
 
             <Ekspanderbartpanel tittel="Eksempler på spørsmål" border>
                 <div className="typo-normal">
@@ -96,47 +86,35 @@ const SlikForegatEtMoteBokmal: React.FC = () => {
                 </div>
             </Ekspanderbartpanel>
 
-            <br />
-
-            <Normaltekst>
+            <Avsnitt>
                 Når vi vet hva du trenger hjelp til, lager vi en plan sammen med
                 deg som vil hjelpe deg videre.
-            </Normaltekst>
+            </Avsnitt>
 
-            <br />
-
-            <Normaltekst>
+            <Avsnitt>
                 Hvis du skal søke økonomisk sosialhjelp, så bør du ha med deg{" "}
                 <Lenke href="./dette-bor-du-vite">dokumentasjon</Lenke> til
                 møtet.
-            </Normaltekst>
+            </Avsnitt>
 
-            <br />
-
-            <Normaltekst>
+            <Avsnitt>
                 Hvis du sliter med noe i livet ditt, psykisk helse, rus,
                 familiesituasjon eller andre ting, bør du si noe om det. Da kan
                 vi gi deg bedre hjelp.
-            </Normaltekst>
+            </Avsnitt>
 
-            <br />
-
-            <Normaltekst>
+            <Avsnitt>
                 Hvis du går på videregående skole og er i konflikt med
                 foreldrene dine, kan det være vi tilbyr en samtale med deg og
                 foreldrene dine.
-            </Normaltekst>
+            </Avsnitt>
 
-            <br />
-
-            <Normaltekst>
+            <Avsnitt>
                 Hvis du ikke snakker eller forstår norsk må du gi oss beskjed,
                 slik at vi kan bestille språktolk til samtalen.
-            </Normaltekst>
+            </Avsnitt>
 
-            <br />
-
-            <Normaltekst>Alle som jobber i NAV har taushetsplikt.</Normaltekst>
+            <Avsnitt>Alle som jobber i NAV har taushetsplikt.</Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/slik-foregar-et-mote/SlikForegatEtMoteEngelsk.tsx
+++ b/src/artikler/slik-foregar-et-mote/SlikForegatEtMoteEngelsk.tsx
@@ -1,15 +1,11 @@
 import * as React from "react";
-import {
-    Ingress,
-    Innholdstittel,
-    Normaltekst,
-    Undertittel,
-} from "nav-frontend-typografi";
+import {Ingress, Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Artikkel from "../Artikkel";
 import Veiskilt from "../../komponenter/bilder/Veiskilt";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import Lenke from "nav-frontend-lenker";
 import {andreMuligheterBrodsmulestiEngelsk} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const SlikForegatEtMoteEngelsk: React.FC = () => {
     return (
@@ -26,127 +22,110 @@ const SlikForegatEtMoteEngelsk: React.FC = () => {
                 contact NAV and schedule an meeting.
             </Ingress>
 
-            <br />
-
-            <Normaltekst>
+            <Avsnitt>
                 You may be feeling insecure before your first meeting with NAV,
                 wondering how much you will be expected to share about your
                 situation. If you prefer, you may bring someone along whom you
                 trust.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 During the meeting, we will ask you some questions to find out
                 what your needs are.
-            </Normaltekst>
+            </Avsnitt>
 
-            <br />
             <Ekspanderbartpanel tittel="Examples of questions" border>
-                <>
-                    <div className="typo-normal">
-                        <ul>
-                            <li>
-                                Are you in school? Are you enrolled in an
-                                education programme? Do you work?
-                            </li>
-                            <li>
-                                What are your sources of&nbsp;income, and what
-                                kinds of expenses do you have?
-                            </li>
-                            <li>
-                                Do you have any savings? Do you have any debt?
-                            </li>
-                            <li>How do you live, and whom do you live with?</li>
-                            <li>
-                                How is the overall financial situation in your
-                                household? Do you have a spouse or cohabitant or
-                                children still living at home? How is your
-                                financial situation?
-                            </li>
-                            <li>
-                                Do you have children?&nbsp;What are their needs?
-                                Are the children in kindergarten or
-                                school?&nbsp;Do the children participate in any
-                                activities?
-                            </li>
-                            <li>
-                                Do you have dyslexia or any other learning
-                                disability?
-                            </li>
-                            <li>
-                                Are you in touch with any other services, such
-                                as the follow-up service (OT), a district
-                                psychiatric outpatient service (DPS) or child
-                                welfare services?
-                            </li>
-                            <li>
-                                What other potential&nbsp;sources of income have
-                                you tried?
-                            </li>
-                            <li>
-                                What do you believe is the solution to the
-                                challenges you are facing?
-                            </li>
-                        </ul>
-                    </div>
-                    <Undertittel>
-                        If you do not have a permanent place to live, we may ask
-                        you
-                    </Undertittel>
-                    <div className="typo-normal">
-                        <ul>
-                            <li>
-                                where you are staying, and how long you have
-                                been staying there.
-                            </li>
-                            <li>
-                                if you have been in contact with NAV in another
-                                municipality and how they helped you.
-                            </li>
-                            <li>
-                                if you need a temporary place to live. We may
-                                ask you about your family and social network to
-                                find out what your other options are.
-                            </li>
-                        </ul>
-                    </div>
-                </>
+                <div className="typo-normal">
+                    <ul>
+                        <li>
+                            Are you in school? Are you enrolled in an education
+                            programme? Do you work?
+                        </li>
+                        <li>
+                            What are your sources of&nbsp;income, and what kinds
+                            of expenses do you have?
+                        </li>
+                        <li>Do you have any savings? Do you have any debt?</li>
+                        <li>How do you live, and whom do you live with?</li>
+                        <li>
+                            How is the overall financial situation in your
+                            household? Do you have a spouse or cohabitant or
+                            children still living at home? How is your financial
+                            situation?
+                        </li>
+                        <li>
+                            Do you have children?&nbsp;What are their needs? Are
+                            the children in kindergarten or school?&nbsp;Do the
+                            children participate in any activities?
+                        </li>
+                        <li>
+                            Do you have dyslexia or any other learning
+                            disability?
+                        </li>
+                        <li>
+                            Are you in touch with any other services, such as
+                            the follow-up service (OT), a district psychiatric
+                            outpatient service (DPS) or child welfare services?
+                        </li>
+                        <li>
+                            What other potential&nbsp;sources of income have you
+                            tried?
+                        </li>
+                        <li>
+                            What do you believe is the solution to the
+                            challenges you are facing?
+                        </li>
+                    </ul>
+                </div>
+                <Undertittel>
+                    If you do not have a permanent place to live, we may ask you
+                </Undertittel>
+                <div className="typo-normal">
+                    <ul>
+                        <li>
+                            where you are staying, and how long you have been
+                            staying there.
+                        </li>
+                        <li>
+                            if you have been in contact with NAV in another
+                            municipality and how they helped you.
+                        </li>
+                        <li>
+                            if you need a temporary place to live. We may ask
+                            you about your family and social network to find out
+                            what your other options are.
+                        </li>
+                    </ul>
+                </div>
             </Ekspanderbartpanel>
-            <br />
 
-            <Normaltekst>
+            <Avsnitt>
                 When we have identified what you need help with, we will work
                 with you to create a plan for how to proceed.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 If you are applying for financial assistance, you should bring{" "}
                 <Lenke href="./dette-bor-du-vite?lang=en">documentation</Lenke>{" "}
                 to the meeting.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 If you are struggling with something in your life, such as your
                 mental health, drugs or alcohol abuse, family problems or other
                 things, you should mention it in the meeting. When we know, we
                 will be better able to help you.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 If you are in upper secondary school and you are in conflict
                 with your parents, we may recommend that you and your parents
                 come to a meeting together.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 If you do not speak or understand Norwegian, you must let us
                 know beforehand, so that we can book an interpreter for the
                 meeting.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 Everyone who works in NAV is bound by a duty of confidentiality.
-            </Normaltekst>
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/slik-foregar-et-mote/SlikForegatEtMoteNynorsk.tsx
+++ b/src/artikler/slik-foregar-et-mote/SlikForegatEtMoteNynorsk.tsx
@@ -1,15 +1,11 @@
 import * as React from "react";
-import {
-    Ingress,
-    Innholdstittel,
-    Normaltekst,
-    Undertittel,
-} from "nav-frontend-typografi";
+import {Ingress, Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Artikkel from "../Artikkel";
 import Veiskilt from "../../komponenter/bilder/Veiskilt";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import Lenke from "nav-frontend-lenker";
 import {andreMuligheterBrodsmulestiNynorsk} from "../andre-muligheter/AndreMuligheter";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const SlikForegatEtMoteNynorsk: React.FC = () => {
     return (
@@ -24,111 +20,95 @@ const SlikForegatEtMoteNynorsk: React.FC = () => {
                 innkalla til ein samtale med ein rettleiar. Du kan òg kontakte
                 NAV-kontoret ditt og avtale eit møte.
             </Ingress>
-            <br />
-            <Normaltekst>
+            <Avsnitt>
                 Det kan hende du er usikker før det første møtet hjå NAV, og
                 lurer på kor mykje du må fortelle om situasjonen din. Dersom du
                 ønskjer det, kan du ta med deg ein person du har tillit til.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 I møtet vil vi stille deg nokre spørsmål for å finne ut kva
                 behov du har.
-            </Normaltekst>
-            <br />
+            </Avsnitt>
 
             <Ekspanderbartpanel tittel="Døme på spørsmål" border>
-                <>
-                    <div className="typo-normal">
-                        <ul>
-                            <li>
-                                Går du på skule? Er du under utdanning? Jobbar
-                                du?
-                            </li>
-                            <li>Kva inntekter og utgifter har du?</li>
-                            <li>Har du pengar i banken? Har du gjeld?</li>
-                            <li>Korleis bur du og kven bur du saman med?</li>
-                            <li>
-                                Korleis ser den samla økonomiske situasjonen i
-                                hushaldet ditt ut? Har du ektefelle, sambuar
-                                eller heimebuande barn? Korleis er deira
-                                økonomiske situasjon?
-                            </li>
-                            <li>
-                                Har du barn? Kva behov har dei? Går dei i
-                                barnehage eller skule? Deltek barna i
-                                aktivitetar?
-                            </li>
-                            <li>Har du lese- og skrivevanskar?</li>
-                            <li>
-                                Har du har kontakt med andre hjelpeinstansar,
-                                til dømes oppfølgingstenesta (OT),
-                                distriktspsykiatrisk senter (DPS) eller
-                                barnevernet?
-                            </li>
-                            <li>
-                                Kva andre inntektsmoglegheiter har du forsøkt?
-                            </li>
-                            <li>
-                                Kva løysingar ser du sjølv føre deg på dei
-                                utfordringane du har?
-                            </li>
-                        </ul>
-                    </div>
-                    <Undertittel>
-                        Dersom du ikkje har ein fast stad å bu, kan du få
-                        spørsmål om
-                    </Undertittel>
-                    <div className="typo-normal">
-                        <ul>
-                            <li>
-                                kor du oppheld deg og kor lenge du har oppheldt
-                                deg der
-                            </li>
-                            <li>
-                                du har vore i kontakt med eit NAV-kontor i ein
-                                annan kommune og kva hjelp du har fått derifrå
-                            </li>
-                            <li>
-                                du treng eit midlertidig butilbod. Då vil du
-                                kunne få spørsmål om familie og nettverk for å
-                                finne ut kva andre moglegheiter du har.
-                            </li>
-                        </ul>
-                    </div>
-                </>
+                <div className="typo-normal">
+                    <ul>
+                        <li>
+                            Går du på skule? Er du under utdanning? Jobbar du?
+                        </li>
+                        <li>Kva inntekter og utgifter har du?</li>
+                        <li>Har du pengar i banken? Har du gjeld?</li>
+                        <li>Korleis bur du og kven bur du saman med?</li>
+                        <li>
+                            Korleis ser den samla økonomiske situasjonen i
+                            hushaldet ditt ut? Har du ektefelle, sambuar eller
+                            heimebuande barn? Korleis er deira økonomiske
+                            situasjon?
+                        </li>
+                        <li>
+                            Har du barn? Kva behov har dei? Går dei i barnehage
+                            eller skule? Deltek barna i aktivitetar?
+                        </li>
+                        <li>Har du lese- og skrivevanskar?</li>
+                        <li>
+                            Har du har kontakt med andre hjelpeinstansar, til
+                            dømes oppfølgingstenesta (OT), distriktspsykiatrisk
+                            senter (DPS) eller barnevernet?
+                        </li>
+                        <li>Kva andre inntektsmoglegheiter har du forsøkt?</li>
+                        <li>
+                            Kva løysingar ser du sjølv føre deg på dei
+                            utfordringane du har?
+                        </li>
+                    </ul>
+                </div>
+                <Undertittel>
+                    Dersom du ikkje har ein fast stad å bu, kan du få spørsmål
+                    om
+                </Undertittel>
+                <div className="typo-normal">
+                    <ul>
+                        <li>
+                            kor du oppheld deg og kor lenge du har oppheldt deg
+                            der
+                        </li>
+                        <li>
+                            du har vore i kontakt med eit NAV-kontor i ein annan
+                            kommune og kva hjelp du har fått derifrå
+                        </li>
+                        <li>
+                            du treng eit midlertidig butilbod. Då vil du kunne
+                            få spørsmål om familie og nettverk for å finne ut
+                            kva andre moglegheiter du har.
+                        </li>
+                    </ul>
+                </div>
             </Ekspanderbartpanel>
 
-            <br />
-            <Normaltekst>
+            <Avsnitt>
                 Når vi veit kva du treng hjelp til, lagar vi ein plan saman med
                 deg som vil hjelpe deg vidare.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 Dersom du skal søkje økonomisk sosialhjelp, bør du ha med deg{" "}
                 <Lenke href="./dette-bor-du-vite?lang=nn">dokumentasjon</Lenke>{" "}
                 til møtet.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 Dersom du slit med noko i livet ditt, psykisk helse, rus,
                 familiesituasjon eller andre ting, bør du seie noko om det. Då
                 kan vi gi deg betre hjelp.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 Dersom du går på vidaregåande skule og er i konflikt med
                 foreldra dine, kan det vere vi tilbyr ein samtale med deg og
                 foreldra dine.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 Om du ikkje snakkar eller forstår norsk må du gi oss beskjed,
                 slik at vi kan bestille språktolk til samtalen.
-            </Normaltekst>
-            <br />
-            <Normaltekst>Alle som jobbar i NAV har teieplikt.</Normaltekst>
+            </Avsnitt>
+            <Avsnitt>Alle som jobbar i NAV har teieplikt.</Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/sok-sosialhjelp/SokSosialhjelpBokmal.tsx
+++ b/src/artikler/sok-sosialhjelp/SokSosialhjelpBokmal.tsx
@@ -22,6 +22,7 @@ import AapneLukkeLenke from "./komponenter/aapneLukkeLenke/AapneLukkeLenke";
 import useTilgjengeligeKommunerService from "./komponenter/kommunesok/service/useTilgjengeligeKommunerService";
 import HjelpeVideo from "./komponenter/hjelpevideo/HjelpeVideo";
 import {ANTALL_KOMMUNER} from "./SokSosialhjelp";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const SokSosialhjelpBokmal: React.FC = () => {
     const [kommuneId, setKommuneId] = useState<string | undefined>(undefined);
@@ -45,13 +46,11 @@ const SokSosialhjelpBokmal: React.FC = () => {
         <Artikkel tittel="Søk om økonomisk sosialhjelp">
             <Innholdstittel>Søk om økonomisk sosialhjelp</Innholdstittel>
 
-            <Normaltekst>
+            <Avsnitt>
                 Du skal søke til NAV-kontoret der du bor. Stadig flere kommuner
                 kan ta i mot digitale søknader. Hvis du ikke skal søke digitalt,
                 kan du søke med kommunens papirskjema.
-            </Normaltekst>
-
-            <br />
+            </Avsnitt>
 
             <SokDigitaltPanel>
                 <Undertittel className="sok_digitalt_overskrift">
@@ -91,7 +90,7 @@ const SokSosialhjelpBokmal: React.FC = () => {
                     Søk digitalt
                 </Hovedknapp>
 
-                <Normaltekst>
+                <Avsnitt>
                     Digital søknad om økonomisk sosialhjelp skal innen kort tid
                     være tilgjengelig for hele landet.{" "}
                     {tilgjengeligeKommunerService.restStatus ===
@@ -105,8 +104,7 @@ const SokSosialhjelpBokmal: React.FC = () => {
                             ta imot digital søknad.
                         </>
                     )}
-                </Normaltekst>
-                <br />
+                </Avsnitt>
                 {!(
                     nedetidService.restStatus === REST_STATUS.OK &&
                     nedetidService.payload.isNedetid
@@ -148,30 +146,26 @@ const SokSosialhjelpBokmal: React.FC = () => {
                 )}
             </SokDigitaltPanel>
 
-            <br />
-            <br />
-
             <IkkeSokDigitaltPanel>
                 <Undertittel>Hvis du ikke skal søke digitalt</Undertittel>
-                <br />
-                <Normaltekst>
+
+                <Avsnitt>
                     Hvis du ikke skal søke digitalt, kan du levere{" "}
                     <Lenke href={"./sok-papir?lang=nb"}>søknad på papir</Lenke>.
-                </Normaltekst>
+                </Avsnitt>
 
-                <br />
                 <Element>
                     Hvorfor kan ikke alle kommuner ta imot digital søknad?
                 </Element>
-                <Normaltekst>
+                <Avsnitt>
                     Stadig flere kommuner kan ta i mot digitale søknader. Hver
                     enkelt kommune bestemmer selv om de skal ta i bruk digital
                     søknad, og eventuelt når det skal skje. Ta kontakt med
                     kommunen din hvis du vil ha svar på om og når du kan søke
                     digitalt i din kommune.
-                </Normaltekst>
+                </Avsnitt>
             </IkkeSokDigitaltPanel>
-            <br />
+
             <h3>Kom i gang med digital søknad</h3>
             <HjelpeVideo tittel="Kom i gang" />
         </Artikkel>

--- a/src/artikler/sok-sosialhjelp/SokSosialhjelpEngelsk.tsx
+++ b/src/artikler/sok-sosialhjelp/SokSosialhjelpEngelsk.tsx
@@ -21,6 +21,7 @@ import useTilgjengeligeKommunerService from "./komponenter/kommunesok/service/us
 import AapneLukkeLenke from "./komponenter/aapneLukkeLenke/AapneLukkeLenke";
 import {UnmountClosed} from "react-collapse";
 import {ANTALL_KOMMUNER} from "./SokSosialhjelp";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const SokSosialhjelpEngelsk: React.FC = () => {
     const [kommuneId, setKommuneId] = useState<string | undefined>(undefined);
@@ -44,15 +45,13 @@ const SokSosialhjelpEngelsk: React.FC = () => {
         <Artikkel tittel="Apply for financial assistance">
             <Innholdstittel>Apply for financial assistance</Innholdstittel>
 
-            <Normaltekst>
+            <Avsnitt>
                 You must apply to the NAV office in the municipality where you
                 live. A growing number of municipalities support digital
                 applications online at nav.no. You can still use the
                 municipality's own paper form if you are not going to apply
                 digitally.
-            </Normaltekst>
-
-            <br />
+            </Avsnitt>
 
             <SokDigitaltPanel>
                 <Undertittel className="sok_digitalt_overskrift">
@@ -66,7 +65,7 @@ const SokSosialhjelpEngelsk: React.FC = () => {
                     Apply digitally
                 </Hovedknapp>
 
-                <Normaltekst>
+                <Avsnitt>
                     All municipalities should be able to receive digital
                     applications shortly.{" "}
                     {tilgjengeligeKommunerService.restStatus ===
@@ -80,7 +79,7 @@ const SokSosialhjelpEngelsk: React.FC = () => {
                             can receive applications digitally.
                         </>
                     )}
-                </Normaltekst>
+                </Avsnitt>
 
                 {nedetidService.restStatus === REST_STATUS.OK &&
                     nedetidService.payload.isNedetid && (
@@ -144,33 +143,28 @@ const SokSosialhjelpEngelsk: React.FC = () => {
                 )}
             </SokDigitaltPanel>
 
-            <br />
-            <br />
-
             <IkkeSokDigitaltPanel>
                 <Undertittel>
                     If you are not going to apply digitally
                 </Undertittel>
 
-                <br />
-                <Normaltekst>
+                <Avsnitt>
                     You can use the{" "}
                     <Lenke href={"./sok-papir?lang=en"}>
                         municipality's own paper form
                     </Lenke>{" "}
                     if you are not going to apply digitally.
-                </Normaltekst>
+                </Avsnitt>
 
-                <br />
                 <Element>
                     Why can't all municipalities accept digital applications?
                 </Element>
-                <Normaltekst>
+                <Avsnitt>
                     A growing number of municipalities support digital
                     applications, but it is up to each municipality to decide
                     when and if they are going to support this. Contact your
                     municipality for more details of their plans.
-                </Normaltekst>
+                </Avsnitt>
             </IkkeSokDigitaltPanel>
         </Artikkel>
     );

--- a/src/artikler/sok-sosialhjelp/SokSosialhjelpNynorsk.tsx
+++ b/src/artikler/sok-sosialhjelp/SokSosialhjelpNynorsk.tsx
@@ -21,6 +21,7 @@ import useTilgjengeligeKommunerService from "./komponenter/kommunesok/service/us
 import AapneLukkeLenke from "./komponenter/aapneLukkeLenke/AapneLukkeLenke";
 import {UnmountClosed} from "react-collapse";
 import {ANTALL_KOMMUNER} from "./SokSosialhjelp";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const SokSosialhjelpNynorsk: React.FC = () => {
     const [kommuneId, setKommuneId] = useState<string | undefined>(undefined);
@@ -43,13 +44,11 @@ const SokSosialhjelpNynorsk: React.FC = () => {
         <Artikkel tittel="Søk om økonomisk sosialhjelp">
             <Innholdstittel>Søk om økonomisk sosialhjelp</Innholdstittel>
 
-            <Normaltekst>
+            <Avsnitt>
                 Du skal søkje til NAV-kontoret der du bur. Stadig fleire
                 kommunar kan ta imot digitale søknader. Dersom du ikkje skal
                 søkje digitalt, kan du søkje med kommunen sitt papirskjema.
-            </Normaltekst>
-
-            <br />
+            </Avsnitt>
 
             <SokDigitaltPanel>
                 <Undertittel className="sok_digitalt_overskrift">
@@ -90,7 +89,7 @@ const SokSosialhjelpNynorsk: React.FC = () => {
                             Søk digitalt
                         </Hovedknapp>
 
-                        <Normaltekst>
+                        <Avsnitt>
                             Digital søknad om økonomisk sosialhjelp vil snart
                             vere tilgjengeleg for heile landet.{" "}
                             {tilgjengeligeKommunerService.restStatus ===
@@ -104,8 +103,7 @@ const SokSosialhjelpNynorsk: React.FC = () => {
                                     ta imot digital søknad.
                                 </>
                             )}
-                        </Normaltekst>
-                        <br />
+                        </Avsnitt>
 
                         <UnmountClosed isOpened={lesMer}>
                             <KommuneSok
@@ -140,29 +138,24 @@ const SokSosialhjelpNynorsk: React.FC = () => {
                 )}
             </SokDigitaltPanel>
 
-            <br />
-            <br />
-
             <IkkeSokDigitaltPanel>
                 <Undertittel>Dersom du ikkje skal søkje digitalt</Undertittel>
 
-                <br />
-                <Normaltekst>
+                <Avsnitt>
                     Dersom du ikkje skal søkje digitalt, kan du levere{" "}
                     <Lenke href={"./sok-papir?lang=nn"}>søknad på papir</Lenke>.
-                </Normaltekst>
+                </Avsnitt>
 
-                <br />
                 <Element>
                     Kvifor kan ikkje alle kommunar ta imot digital søknad?
                 </Element>
-                <Normaltekst>
+                <Avsnitt>
                     Stadig fleire kommunar kan ta imot digitale søknader. Kvar
                     enkelt kommune kan sjølv bestemme om dei vil ta i bruk
                     digital søknad, og eventuelt når det skal skje. Ta kontakt
                     med kommunen din dersom du vil ha svar på om og når du kan
                     søkje digitalt i din kommune.
-                </Normaltekst>
+                </Avsnitt>
             </IkkeSokDigitaltPanel>
         </Artikkel>
     );

--- a/src/artikler/sok-sosialhjelp/komponenter/IkkeSokDigitalt.tsx
+++ b/src/artikler/sok-sosialhjelp/komponenter/IkkeSokDigitalt.tsx
@@ -6,14 +6,16 @@ const IkkeSokDigitaltPanel: React.FC<{children: React.ReactNode}> = ({
     children,
 }) => {
     return (
-        <Veilederpanel
-            type={"plakat"}
-            kompakt={true}
-            fargetema="suksess"
-            svg={<BrevHender />}
-        >
-            <span className="ikke_digitalt_sok_panel">{children}</span>
-        </Veilederpanel>
+        <div style={{margin: "5em 0 0 0"}}>
+            <Veilederpanel
+                type={"plakat"}
+                kompakt={true}
+                fargetema="suksess"
+                svg={<BrevHender />}
+            >
+                <span className="ikke_digitalt_sok_panel">{children}</span>
+            </Veilederpanel>
+        </div>
     );
 };
 

--- a/src/artikler/sok-sosialhjelp/komponenter/IkkeSokDigitalt.tsx
+++ b/src/artikler/sok-sosialhjelp/komponenter/IkkeSokDigitalt.tsx
@@ -6,7 +6,7 @@ const IkkeSokDigitaltPanel: React.FC<{children: React.ReactNode}> = ({
     children,
 }) => {
     return (
-        <div style={{margin: "5em 0 0 0"}}>
+        <div className="sok_sosialhjelp_wrapper">
             <Veilederpanel
                 type={"plakat"}
                 kompakt={true}

--- a/src/artikler/sok-sosialhjelp/komponenter/SokDigitaltPanel.tsx
+++ b/src/artikler/sok-sosialhjelp/komponenter/SokDigitaltPanel.tsx
@@ -6,14 +6,16 @@ const SokDigitaltPanel: React.FC<{children: React.ReactNode}> = ({
     children,
 }) => {
     return (
-        <Veilederpanel
-            type={"plakat"}
-            kompakt={true}
-            svg={<Tastatur />}
-            fargetema="suksess"
-        >
-            <span className="sok_sosialhjelp_panel">{children}</span>
-        </Veilederpanel>
+        <div style={{margin: "5em 0 0 0"}}>
+            <Veilederpanel
+                type={"plakat"}
+                kompakt={true}
+                svg={<Tastatur />}
+                fargetema="suksess"
+            >
+                <span className="sok_sosialhjelp_panel">{children}</span>
+            </Veilederpanel>
+        </div>
     );
 };
 

--- a/src/artikler/sok-sosialhjelp/komponenter/SokDigitaltPanel.tsx
+++ b/src/artikler/sok-sosialhjelp/komponenter/SokDigitaltPanel.tsx
@@ -6,7 +6,7 @@ const SokDigitaltPanel: React.FC<{children: React.ReactNode}> = ({
     children,
 }) => {
     return (
-        <div style={{margin: "5em 0 0 0"}}>
+        <div className="sok_sosialhjelp_wrapper">
             <Veilederpanel
                 type={"plakat"}
                 kompakt={true}

--- a/src/artikler/sok-sosialhjelp/komponenter/sokSosialhjelp.less
+++ b/src/artikler/sok-sosialhjelp/komponenter/sokSosialhjelp.less
@@ -1,3 +1,7 @@
+.sok_sosialhjelp_wrapper {
+    margin: 5em 0 2em 0;
+}
+
 .artikkel .innhold .sok_sosialhjelp_panel {
     text-align: center;
     display: block;

--- a/src/artikler/soknad-pa-papir/SoknadPaPapirBokmal.tsx
+++ b/src/artikler/soknad-pa-papir/SoknadPaPapirBokmal.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 import Artikkel from "../Artikkel";
 import "../artikkel.less";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const SoknadPaPapirBokmal: React.FC = () => {
     return (
@@ -10,34 +11,32 @@ const SoknadPaPapirBokmal: React.FC = () => {
             <Innholdstittel>
                 Hvor finner du søknadsskjema på papir
             </Innholdstittel>
-            <Normaltekst>
+            <Avsnitt>
                 Dessverre finnes det ikke et felles papirskjema for økonomisk
                 sosialhjelp. Hver kommune har et eget søknadskjema som du kan
                 benytte hvis du ikke kan søke digitalt.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Last ned papirskjema på nett</Undertittel>
 
-            <Normaltekst>
+            <Avsnitt>
                 Du finner ikke papirskjema på NAV.no, men mange kommuner har
                 søknadskjema sitt tilgjengelig på sine nettsider. Du finner
                 kommunens nettside på:
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 www.[din kommune].kommune.no
                 <br />
                 f.eks. www.oslo.kommune.no
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Hent papirskjema på ditt NAV-kontor</Undertittel>
 
-            <Normaltekst>
+            <Avsnitt>
                 Hvis du ikke finner søknadsskjema på kommunen din sine
                 nettsider, kan du hente papirskjema på NAV-kontoret ditt.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 Du finner adresse og telefonnummer til ditt nærmeste kontor
                 under finn{" "}
                 <Lenke
@@ -48,10 +47,10 @@ const SoknadPaPapirBokmal: React.FC = () => {
                     ditt NAV-kontor
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Når du skal levere søknaden</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 Du kan levere søknaden på{" "}
                 <Lenke
                     href={
@@ -61,10 +60,10 @@ const SoknadPaPapirBokmal: React.FC = () => {
                     ditt NAV-kontor
                 </Lenke>{" "}
                 eller sende den i posten.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Hvis du trenger hjelp</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 Ta kontakt med{" "}
                 <Lenke
                     href={
@@ -75,7 +74,7 @@ const SoknadPaPapirBokmal: React.FC = () => {
                 </Lenke>{" "}
                 hvis du trenger hjelp til å finne søknadsskjema eller fylle ut
                 søknaden.
-            </Normaltekst>
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/soknad-pa-papir/SoknadPaPapirEnglish.tsx
+++ b/src/artikler/soknad-pa-papir/SoknadPaPapirEnglish.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
+import {Innholdstittel, Undertittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 import Artikkel from "../Artikkel";
 import "../artikkel.less";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const SoknadPaPapirEnglish: React.FC = () => {
     return (
@@ -10,34 +11,32 @@ const SoknadPaPapirEnglish: React.FC = () => {
             <Innholdstittel>
                 Where to find application form on paper
             </Innholdstittel>
-            <Normaltekst>
+            <Avsnitt>
                 Unfortunately, there is no common application form when you
                 apply on paper. Each municipality has its own application form
                 that you should use if you cannot apply digitally.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Download application form online</Undertittel>
 
-            <Normaltekst>
+            <Avsnitt>
                 You can not find the paper form on NAV.no, but many
                 municipalities have their form available on their website. You
                 can find the municipality's website at:
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 www.[your municipality].kommune.no
                 <br />
                 for example. www.oslo.kommune.no
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>Get a paper form at your NAV office</Undertittel>
 
-            <Normaltekst>
+            <Avsnitt>
                 If you cannot find an application form on your municipality's
                 website, you can obtain a paper form at your NAV office.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 You can find the address and telephone number of your nearest
                 office under find{" "}
                 <Lenke
@@ -48,10 +47,10 @@ const SoknadPaPapirEnglish: React.FC = () => {
                     your NAV office
                 </Lenke>
                 .
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>When to submit the application</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 You can submit the application to{" "}
                 <Lenke
                     href={
@@ -61,10 +60,10 @@ const SoknadPaPapirEnglish: React.FC = () => {
                     your NAV office
                 </Lenke>{" "}
                 or send it by mail.
-            </Normaltekst>
+            </Avsnitt>
 
             <Undertittel>If you need help</Undertittel>
-            <Normaltekst>
+            <Avsnitt>
                 Contact{" "}
                 <Lenke
                     href={
@@ -75,7 +74,7 @@ const SoknadPaPapirEnglish: React.FC = () => {
                 </Lenke>{" "}
                 if you need help finding an application form or filling out the
                 application.
-            </Normaltekst>
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/artikler/status-soknad/StatusSoknadBokmal.tsx
+++ b/src/artikler/status-soknad/StatusSoknadBokmal.tsx
@@ -1,28 +1,28 @@
 import * as React from "react";
-import {Innholdstittel, Normaltekst} from "nav-frontend-typografi";
+import {Innholdstittel} from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 import Artikkel from "../Artikkel";
 import "../artikkel.less";
+import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 
 const StatusSoknadBokmal: React.FC = () => {
     return (
         <Artikkel tittel="Hvor kan du se status på søknaden?">
             <Innholdstittel>Hvor kan du se status på søknaden?</Innholdstittel>
-            <Normaltekst>
+            <Avsnitt>
                 Hvis du har søkt digitalt, finner du en liste over alle{" "}
                 <Lenke href={"./innsyn"}>dine sosialhjelpssøknader</Lenke> på
                 ditt NAV. Her kan du se tidspunktet søknaden ble sendt og hvilke
                 vedlegg som mangler til søknaden. Den digitale løsningen er
                 under utvikling, og etter hvert vil du også kunne se status på
                 søknaden din.
-            </Normaltekst>
-            <br />
-            <Normaltekst>
+            </Avsnitt>
+            <Avsnitt>
                 Stadig flere kommuner tar i bruk de nye digitale mulighetene.
-                For øyeblikket er det bare innbyggere i enkelte kommuner som
-                kan følge med på status på søknaden, men etter hvert vil også
-                resten av Norge bli med!
-            </Normaltekst>
+                For øyeblikket er det bare innbyggere i enkelte kommuner som kan
+                følge med på status på søknaden, men etter hvert vil også resten
+                av Norge bli med!
+            </Avsnitt>
         </Artikkel>
     );
 };

--- a/src/index.less
+++ b/src/index.less
@@ -34,6 +34,11 @@ body {
     }
 }
 
+.avsnitt {
+    margin-block-start: 1rem;
+    margin-block-end: 1rem;
+}
+
 .forsideBanner {
     width: 100%;
     background-color: white;

--- a/src/komponenter/avsnitt/Avsnitt.tsx
+++ b/src/komponenter/avsnitt/Avsnitt.tsx
@@ -1,0 +1,6 @@
+import {Normaltekst} from "nav-frontend-typografi";
+import React from "react";
+
+export const Avsnitt = (props: {children: any}) => (
+    <Normaltekst className="avsnitt">{props.children}</Normaltekst>
+);


### PR DESCRIPTION
Beklager litt stor PR, er sånn det går når små endringer skal gjøres i mange filer...

Har laget et eget komponent som heter `Avsnitt`. Denne legger på en ekstra klasse på `Normaltekst` som inkluderer marger. Fjernet samtidig linjeskift med `<br />` der dette var brukt tidligere for å skape luft mellom avsnittene.