### PR TITLE
Fjerner ubrukte ingresser og legger til dev.nav.no

### DIFF
--- a/nais/dev/q0.json
+++ b/nais/dev/q0.json
@@ -1,9 +1,8 @@
 {
   "namespace": "q0",
   "ingresses": [
-    "https://sosialhjelp-veiviser-q0.nais.oera-q.local/",
     "https://sosialhjelp-veiviser-q0.dev-sbs.nais.io/",
-    "https://tjenester-q0.nav.no/sosialhjelp-veiviser",
+    "https://www-q0.dev.nav.no/sosialhjelp",
     "https://www-q0.nav.no/sosialhjelp"
   ],
   "prometheusEnabled": true,

--- a/nais/dev/q1.json
+++ b/nais/dev/q1.json
@@ -1,9 +1,8 @@
 {
   "namespace": "q1",
   "ingresses": [
-    "https://sosialhjelp-veiviser-q1.nais.oera-q.local/",
     "https://sosialhjelp-veiviser-q1.dev-sbs.nais.io/",
-    "https://tjenester-q1.nav.no/sosialhjelp-veiviser",
+    "https://www-q1.dev.nav.no/sosialhjelp",
     "https://www-q1.nav.no/sosialhjelp"
   ],
   "prometheusEnabled": true,

--- a/src/utils/navigasjon.ts
+++ b/src/utils/navigasjon.ts
@@ -27,7 +27,7 @@ const onClickLink = (event: any, sti: string) => {
 const gaaTilDigitalSoknad = (kommuneId?: string): void => {
     const query = kommuneId !== undefined ? "?kommuneId=" + kommuneId : "";
     let soknadUrl: string = "/sosialhjelp/soknad/informasjon" + query;
-    if (window.location.origin.indexOf(".dev.nav.no") >= 0) {
+    if (window.location.origin.indexOf("sosialhjelp-veiviser.dev.nav.no") >= 0) {
         soknadUrl =
             "https://sosialhjelp-soknad.dev.nav.no/sosialhjelp/soknad/mock-login";
     } else if (window.location.origin.indexOf("digisos.labs.nais.io") >= 0) {


### PR DESCRIPTION
Fordi loginservice er kun tilgjengelig fra naisdevice på dev.nav.no, og for å ta i bruk denne må appene våre kjøre på samme ingress.