### PR TITLE
Tar i bruk nav-frontend-input og legger ved feilmelding dersom kommunen ikke finnes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1484,6 +1484,11 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
+    "@navikt/fnrvalidator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@navikt/fnrvalidator/-/fnrvalidator-1.1.3.tgz",
+      "integrity": "sha512-xBwlPOI08kbByUWI4Yyd6NbIYLFs78I0h05mlHPjmrPPikyM89IQRbMac+6ovkgpi2s63OV6ryv3w4QqPubwiw=="
+    },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
@@ -10225,6 +10230,16 @@
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/nav-frontend-paneler-style/-/nav-frontend-paneler-style-0.3.21.tgz",
       "integrity": "sha512-bo3pmByEHH3Hnl8OphcCEcz23nqs3VK05xF+f3m9quzi+TcPHpYSe+V6NrBzFAA6UB6clRo7b8l5j/ANY7prDg=="
+    },
+    "nav-frontend-skjema": {
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/nav-frontend-skjema/-/nav-frontend-skjema-3.0.18.tgz",
+      "integrity": "sha512-zP7X5fFWmUiHqqw8/PLDX8IbSBoeTwrC7phpg2FsUN7FbFlvs3kXMC4szfKz0HagGqqdOF66ginixMFrWGsP9Q=="
+    },
+    "nav-frontend-skjema-style": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/nav-frontend-skjema-style/-/nav-frontend-skjema-style-2.0.10.tgz",
+      "integrity": "sha512-CSqseIXOOoaFKnCLQZGdYzRfm2pljh8xhb1zwo0fzpFwUeHPsyvwBE30u+MvYaJwJ6S6Xj8CWxMOu45fOOaA7A=="
     },
     "nav-frontend-typografi": {
       "version": "2.0.26",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "homepage": "https://www.nav.no/sosialhjelp/",
   "dependencies": {
     "@craco/craco": "^5.6.3",
+    "@navikt/fnrvalidator": "^1.1.3",
     "@sentry/browser": "^5.12.1",
     "@types/react-router": "^5.1.8",
     "babel-polyfill": "^6.26.0",
@@ -38,6 +39,8 @@
     "nav-frontend-lesmerpanel-style": "0.0.31",
     "nav-frontend-paneler": "^2.0.10",
     "nav-frontend-paneler-style": "^0.3.21",
+    "nav-frontend-skjema": "^3.0.18",
+    "nav-frontend-skjema-style": "^2.0.10",
     "nav-frontend-typografi": "^2.0.26",
     "nav-frontend-typografi-style": "^1.0.22",
     "nav-frontend-veileder": "^2.0.21",

--- a/src/artikler/sok-sosialhjelp/komponenter/kommunesok/navAutocomplete/NavAutcomplete.tsx
+++ b/src/artikler/sok-sosialhjelp/komponenter/kommunesok/navAutocomplete/NavAutcomplete.tsx
@@ -1,10 +1,10 @@
 import React, {useState} from "react";
-import { Input } from 'nav-frontend-skjema';
+import {Input} from "nav-frontend-skjema";
 import "./navAutcomplete.less";
 import AutcompleteSuggestion from "./AutcompleteSuggestion";
 import {searchSuggestions} from "./AutcompleteUtils";
 import {isIe} from "../../../../../utils/browserUtils";
-import { detekterSprak, Sprak } from "../../../../../utils/sprakUtils";
+import {detekterSprak, Sprak} from "../../../../../utils/sprakUtils";
 
 interface Props {
     placeholder?: string;
@@ -33,13 +33,14 @@ enum KEY {
 const getFeilmelding = () => {
     const sprak = detekterSprak();
     if (sprak === Sprak.NYNORSK) {
-        return "Vi fant ikkje denne kommunen, vennligst sjekk at du har skrevet det riktig."
+        return "Vi fant ikkje denne kommunen, vennligst sjekk at du har skrevet det riktig.";
     } else if (sprak === Sprak.ENGELSK) {
-        return "We could not find this municipality, please check that it is spelled correctly"
-    } else  { // Defaulter til bokmål
-        return "Vi fant ikke denne kommunen, vennligst sjekk at du har skrevet det riktig."
-    } 
-}
+        return "We could not find this municipality, please check that it is spelled correctly";
+    } else {
+        // Defaulter til bokmål
+        return "Vi fant ikke denne kommunen, vennligst sjekk at du har skrevet det riktig.";
+    }
+};
 
 const NavAutocomplete: React.FC<Props> = ({
     placeholder,
@@ -93,7 +94,8 @@ const NavAutocomplete: React.FC<Props> = ({
                 break;
             case KEY.ENTER:
                 if (displayedSuggestions.length === 0) {
-                    setHasErrors(true)
+                    onReset && onReset();
+                    setHasErrors(true);
                 }
                 if (displayedSuggestions.length === 1) {
                     const displayedSuggestions: Suggestion[] = searchSuggestions(
@@ -115,7 +117,8 @@ const NavAutocomplete: React.FC<Props> = ({
                         );
                         onClick(displayedSuggestions[activeSuggestionIndex]);
                     } else {
-                        setHasErrors(true)
+                        onReset && onReset();
+                        setHasErrors(true);
                         setShouldShowSuggestions(false);
                     }
                 }
@@ -162,7 +165,7 @@ const NavAutocomplete: React.FC<Props> = ({
      */
     const onChangeHandler = (event: any) => {
         const {value} = event.target;
-        setHasErrors(false)
+        setHasErrors(false);
         setValue(value);
         setShouldShowSuggestions(true);
         if (value.length === 0 && onReset) {
@@ -260,12 +263,7 @@ const NavAutocomplete: React.FC<Props> = ({
         >
             <Input
                 id={id}
-                className={
-                    "typo-normal " +
-                    (feil && feil.length > 0
-                        ? "navAutocomplete__input--harFeil"
-                        : "")
-                }
+                className={"typo-normal "}
                 type="search"
                 aria-label={ariaLabel}
                 aria-autocomplete="list"
@@ -315,7 +313,6 @@ const NavAutocomplete: React.FC<Props> = ({
                         )
                     )}
             </ul>
-            {feil && <div className="skjemaelement__feilmelding">Feil</div>}
         </div>
     );
 };

--- a/src/artikler/sok-sosialhjelp/komponenter/kommunesok/navAutocomplete/NavAutcomplete.tsx
+++ b/src/artikler/sok-sosialhjelp/komponenter/kommunesok/navAutocomplete/NavAutcomplete.tsx
@@ -33,12 +33,12 @@ enum KEY {
 const getFeilmelding = () => {
     const sprak = detekterSprak();
     if (sprak === Sprak.NYNORSK) {
-        return "Vi fant ikkje denne kommunen, vennligst sjekk at du har skrevet det riktig.";
+        return "Vi finn ikkje denne kommunen, ver vennleg og sjekk at du har skrive rett";
     } else if (sprak === Sprak.ENGELSK) {
         return "We could not find this municipality, please check that it is spelled correctly";
     } else {
         // Defaulter til bokmål
-        return "Vi fant ikke denne kommunen, vennligst sjekk at du har skrevet det riktig.";
+        return "Vi fant ikke denne kommunen, vennligst sjekk at du har skrevet det riktig";
     }
 };
 

--- a/src/artikler/sok-sosialhjelp/komponenter/kommunesok/navAutocomplete/navAutcomplete.less
+++ b/src/artikler/sok-sosialhjelp/komponenter/kommunesok/navAutocomplete/navAutcomplete.less
@@ -4,28 +4,11 @@
     max-width: 28rem;
     text-align: left;
 
-    .navAutocomplete__input--harFeil {
-        border-color: #ba3a26;
-        background-color: #f3e3e3;
-    }
-
+  
     input {
         padding: 1rem;
-        background-color: white;
         border-radius: 8px;
-        border: 1px solid #b7b1a9;
-        box-sizing: border-box;
-        width: 100%;
         height: 3rem;
-
-        &:hover {
-            border-color: #0067c5;
-        }
-
-        &:focus {
-            outline: none;
-            box-shadow: 0 0 0 3px #ffbd66;
-        }
 
         &::-ms-clear {
             display: none; // Skjul krysset for å tømme input feltet i IE/Edge
@@ -37,7 +20,6 @@
         top: 100%;
         left: 0;
         z-index: 1000;
-        // min-width: 100%;
         max-width: 28rem;
         margin: 0;
         background-color: #fff;


### PR DESCRIPTION
Tekster må avklares før denne kan flettes inn.

Viser feilmelding på kommunesøk ved trykk på enter dersom det ikke finnes forslag, eller dersom ingen av forslagene er valgt.

Mulig vi bør ta en litt større gjennomgang på autocomplete funksjonaliteten, men det blir i så fall en egen PR. Slik logikken er nå vil søk på eks "Os" gi feil, med mindre bruker velger "Os" fra nedtrekkslisten.