### PR TITLE
Oppdaterer lenke og bilde for Jobblyst

### DIFF
--- a/src/artikler/andre-muligheter/JobblystPanel.tsx
+++ b/src/artikler/andre-muligheter/JobblystPanel.tsx
@@ -6,7 +6,7 @@ import "./komponenter/jobblyst_panel.less";
 export const JobblystBokmalPanel = () => {
     return (
         <Lenkepanel
-            href="https://tjenester.nav.no/veiledearbeidssoker/"
+            href="https://www.facebook.com/navjobblyst/"
             tittelProps="normaltekst"
             border={false}
             className="jobblyst_panel"
@@ -21,7 +21,7 @@ export const JobblystBokmalPanel = () => {
 
 export const JobblystNynorskPanel = () => (
     <Lenkepanel
-        href="https://tjenester.nav.no/veiledearbeidssoker/"
+        href="https://www.facebook.com/navjobblyst/"
         tittelProps="normaltekst"
         border={false}
         className="jobblyst_panel"
@@ -35,7 +35,7 @@ export const JobblystNynorskPanel = () => (
 
 export const JobblystEnglishPanel = () => (
     <Lenkepanel
-        href="https://tjenester.nav.no/veiledearbeidssoker/"
+        href="https://www.facebook.com/navjobblyst/"
         tittelProps="normaltekst"
         border={false}
         className="jobblyst_panel"


### PR DESCRIPTION
Vi har fått tilbakemelding på at vi har feil lenke angående Jobblyst i veiviseren. Null problem, det fikser vi kjapt.
Har lagt til lenkene som skal benyttes, men trenger nok litt hjelp med å få på plass nytt bilde for panelet eller noe i den duren.
Tar i mot hjelp med takk.