### PR TITLE
Viser status for innsyn i kommunesøket

### DIFF
--- a/src/artikler/sok-sosialhjelp/SokSosialhjelpBokmal.tsx
+++ b/src/artikler/sok-sosialhjelp/SokSosialhjelpBokmal.tsx
@@ -128,7 +128,7 @@ const SokSosialhjelpBokmal: React.FC = () => {
                                         <Lenke href="https://www.nav.no/sosialhjelp/innsyn">
                                             statusen på søknaden
                                         </Lenke>{" "}
-                                        din på nav.no
+                                        din på nav.no.
                                     </>
                                 }
                                 soknadTilgjengeligUtenInnsynTekst={

--- a/src/artikler/sok-sosialhjelp/SokSosialhjelpBokmal.tsx
+++ b/src/artikler/sok-sosialhjelp/SokSosialhjelpBokmal.tsx
@@ -19,14 +19,18 @@ import AlertStripe from "nav-frontend-alertstriper";
 import Lenke from "nav-frontend-lenker";
 import {UnmountClosed} from "react-collapse";
 import AapneLukkeLenke from "./komponenter/aapneLukkeLenke/AapneLukkeLenke";
-import useTilgjengeligeKommunerService from "./komponenter/kommunesok/service/useTilgjengeligeKommunerService";
+import useTilgjengeligeKommunerService, {
+    antallKommuner,
+} from "./komponenter/kommunesok/service/useTilgjengeligeKommunerService";
 import HjelpeVideo from "./komponenter/hjelpevideo/HjelpeVideo";
 import {ANTALL_KOMMUNER} from "./SokSosialhjelp";
 import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 import {InternLenke} from "../../komponenter/InternLenke";
+import useKommuneNrService from "./komponenter/kommunesok/service/useKommuneNrService";
 
 const SokSosialhjelpBokmal: React.FC = () => {
     const [kommuneId, setKommuneId] = useState<string | undefined>(undefined);
+    const [valgtKommuneNavn, setValgtKommuneNavn] = useState("");
     const nedetidService = useNedetidService();
 
     const sokDigital = (event: any) => {
@@ -37,10 +41,13 @@ const SokSosialhjelpBokmal: React.FC = () => {
     const [lesMer, setLesMer] = useState<boolean>(false);
 
     const tilgjengeligeKommunerService = useTilgjengeligeKommunerService();
+    const kommuneNrService = useKommuneNrService();
 
     let antallTilgjengeligKommuner: string = "";
     if (tilgjengeligeKommunerService.restStatus === REST_STATUS.OK) {
-        antallTilgjengeligKommuner = tilgjengeligeKommunerService.payload.results.length.toString();
+        antallTilgjengeligKommuner = antallKommuner(
+            tilgjengeligeKommunerService.payload.results
+        );
     }
 
     return (
@@ -112,27 +119,52 @@ const SokSosialhjelpBokmal: React.FC = () => {
                 ) && (
                     <>
                         <UnmountClosed isOpened={lesMer}>
-                            <div className="kommunesok_midlertidig">
-                                <KommuneSok
-                                    ledetekst="Sjekk om du kan søke digitalt i din kommune"
-                                    soknadTilgjengeligTekst="Du kan søke digitalt i"
-                                    soknadIkkeTilgjengelig={
-                                        <span>
-                                            kan dessverre ikke ta i mot digitale
-                                            søknader ennå. Du kan{" "}
-                                            <Lenke href={"./sok-papir?lang=nb"}>
-                                                søke på papirskjema
-                                            </Lenke>
-                                            .
-                                        </span>
-                                    }
-                                    placeholderTekst="Skriv kommunenavn"
-                                    ariaLabel="Søk etter kommunenavn"
-                                    onValgtKommune={(
-                                        kommuneId: string | undefined
-                                    ) => setKommuneId(kommuneId)}
-                                />
-                            </div>
+                            <KommuneSok
+                                ledetekst="Sjekk om du kan søke digitalt i din kommune"
+                                soknadOgInnsynTilgjengeligTekst={
+                                    <>
+                                        Du kan søke digitalt i{" "}
+                                        {valgtKommuneNavn}. Du kan også følge{" "}
+                                        <Lenke href="https://www.nav.no/sosialhjelp/innsyn">
+                                            statusen på søknaden
+                                        </Lenke>{" "}
+                                        din på nav.no
+                                    </>
+                                }
+                                soknadTilgjengeligUtenInnsynTekst={
+                                    <>
+                                        Du kan søke digitalt i{" "}
+                                        {valgtKommuneNavn}. Snart kan du også
+                                        følge{" "}
+                                        <InternLenke href="./status-soknad?lang=nb">
+                                            status på søknaden
+                                        </InternLenke>{" "}
+                                        din på nav.no.
+                                    </>
+                                }
+                                soknadIkkeTilgjengeligTekst={
+                                    <>
+                                        Du kan dessverre ikke søke digitalt i{" "}
+                                        {valgtKommuneNavn} ennå. Du kan{" "}
+                                        <Lenke href={"./sok-papir?lang=nb"}>
+                                            søke på papirskjema
+                                        </Lenke>
+                                        .
+                                    </>
+                                }
+                                placeholderTekst="Skriv kommunenavn"
+                                ariaLabel="Søk etter kommunenavn"
+                                tilgjengeligeKommunerService={
+                                    tilgjengeligeKommunerService
+                                }
+                                kommuneNrService={kommuneNrService}
+                                onValgtKommune={(
+                                    kommuneId: string | undefined
+                                ) => setKommuneId(kommuneId)}
+                                setValgtKommuneNavn={(kommuneNavn: string) =>
+                                    setValgtKommuneNavn(kommuneNavn)
+                                }
+                            />
                         </UnmountClosed>
 
                         <Normaltekst>

--- a/src/artikler/sok-sosialhjelp/SokSosialhjelpBokmalForskudd.tsx
+++ b/src/artikler/sok-sosialhjelp/SokSosialhjelpBokmalForskudd.tsx
@@ -15,9 +15,12 @@ import useTilgjengeligeKommunerService from "./komponenter/kommunesok/service/us
 import HjelpeVideo from "./komponenter/hjelpevideo/HjelpeVideo";
 import AapneLukkeLenke from "./komponenter/aapneLukkeLenke/AapneLukkeLenke";
 import {ANTALL_KOMMUNER} from "./SokSosialhjelp";
+import useKommuneNrService from "./komponenter/kommunesok/service/useKommuneNrService";
+import {InternLenke} from "../../komponenter/InternLenke";
 
 const SokSosialhjelpBokmalForskudd: React.FC = () => {
     const [kommuneId, setKommuneId] = useState<string | undefined>(undefined);
+    const [valgtKommuneNavn, setValgtKommuneNavn] = useState("");
     const nedetidService = useNedetidService();
 
     const sokDigital = (event: any) => {
@@ -28,6 +31,7 @@ const SokSosialhjelpBokmalForskudd: React.FC = () => {
     const [lesMer, setLesMer] = useState<boolean>(false);
 
     const tilgjengeligeKommunerService = useTilgjengeligeKommunerService();
+    const kommuneNrService = useKommuneNrService();
 
     let antallTilgjengeligKommuner: string = "";
     if (tilgjengeligeKommunerService.restStatus === REST_STATUS.OK) {
@@ -76,27 +80,52 @@ const SokSosialhjelpBokmalForskudd: React.FC = () => {
                             )}
                         </Normaltekst>
                         <UnmountClosed isOpened={lesMer}>
-                            <div className="kommunesok_midlertidig">
-                                <KommuneSok
-                                    ledetekst="Sjekk om du kan søke digitalt i din kommune"
-                                    soknadTilgjengeligTekst="Du kan søke digitalt i"
-                                    soknadIkkeTilgjengelig={
-                                        <span>
-                                            kan dessverre ikke ta i mot digitale
-                                            søknader ennå. Du kan{" "}
-                                            <Lenke href={"./sok-papir?lang=nb"}>
-                                                søke på papirskjema
-                                            </Lenke>
-                                            .
-                                        </span>
-                                    }
-                                    placeholderTekst="Skriv kommunenavn"
-                                    ariaLabel="Søk etter kommunenavn"
-                                    onValgtKommune={(
-                                        kommuneId: string | undefined
-                                    ) => setKommuneId(kommuneId)}
-                                />
-                            </div>
+                            <KommuneSok
+                                ledetekst="Sjekk om du kan søke digitalt i din kommune"
+                                soknadOgInnsynTilgjengeligTekst={
+                                    <>
+                                        Du kan søke digitalt i{" "}
+                                        {valgtKommuneNavn}. Du kan også følge{" "}
+                                        <Lenke href="https://www.nav.no/sosialhjelp/innsyn">
+                                            statusen på søknaden
+                                        </Lenke>{" "}
+                                        din på nav.no
+                                    </>
+                                }
+                                soknadTilgjengeligUtenInnsynTekst={
+                                    <>
+                                        Du kan søke digitalt i{" "}
+                                        {valgtKommuneNavn}. Snart kan du også
+                                        følge{" "}
+                                        <InternLenke href="./status-soknad?lang=nb">
+                                            status på søknaden
+                                        </InternLenke>{" "}
+                                        din på nav.no.
+                                    </>
+                                }
+                                soknadIkkeTilgjengeligTekst={
+                                    <>
+                                        Du kan dessverre ikke søke digitalt i{" "}
+                                        {valgtKommuneNavn} ennå. Du kan{" "}
+                                        <Lenke href={"./sok-papir?lang=nb"}>
+                                            søke på papirskjema
+                                        </Lenke>
+                                        .
+                                    </>
+                                }
+                                placeholderTekst="Skriv kommunenavn"
+                                ariaLabel="Søk etter kommunenavn"
+                                tilgjengeligeKommunerService={
+                                    tilgjengeligeKommunerService
+                                }
+                                kommuneNrService={kommuneNrService}
+                                onValgtKommune={(
+                                    kommuneId: string | undefined
+                                ) => setKommuneId(kommuneId)}
+                                setValgtKommuneNavn={(kommuneNavn: string) =>
+                                    setValgtKommuneNavn(kommuneNavn)
+                                }
+                            />
                         </UnmountClosed>
 
                         <Normaltekst>

--- a/src/artikler/sok-sosialhjelp/SokSosialhjelpBokmalForskudd.tsx
+++ b/src/artikler/sok-sosialhjelp/SokSosialhjelpBokmalForskudd.tsx
@@ -89,7 +89,7 @@ const SokSosialhjelpBokmalForskudd: React.FC = () => {
                                         <Lenke href="https://www.nav.no/sosialhjelp/innsyn">
                                             statusen på søknaden
                                         </Lenke>{" "}
-                                        din på nav.no
+                                        din på nav.no.
                                     </>
                                 }
                                 soknadTilgjengeligUtenInnsynTekst={

--- a/src/artikler/sok-sosialhjelp/SokSosialhjelpEngelsk.tsx
+++ b/src/artikler/sok-sosialhjelp/SokSosialhjelpEngelsk.tsx
@@ -17,15 +17,19 @@ import {REST_STATUS} from "../../utils/restUtils";
 import useNedetidService from "./komponenter/kommunesok/service/useNedetidService";
 import AlertStripe from "nav-frontend-alertstriper";
 import Lenke from "nav-frontend-lenker";
-import useTilgjengeligeKommunerService from "./komponenter/kommunesok/service/useTilgjengeligeKommunerService";
+import useTilgjengeligeKommunerService, {
+    antallKommuner,
+} from "./komponenter/kommunesok/service/useTilgjengeligeKommunerService";
 import AapneLukkeLenke from "./komponenter/aapneLukkeLenke/AapneLukkeLenke";
 import {UnmountClosed} from "react-collapse";
 import {ANTALL_KOMMUNER} from "./SokSosialhjelp";
 import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 import {InternLenke} from "../../komponenter/InternLenke";
+import useKommuneNrService from "./komponenter/kommunesok/service/useKommuneNrService";
 
 const SokSosialhjelpEngelsk: React.FC = () => {
     const [kommuneId, setKommuneId] = useState<string | undefined>(undefined);
+    const [valgtKommuneNavn, setValgtKommuneNavn] = useState("");
     const nedetidService = useNedetidService();
 
     const sokDigital = (event: any) => {
@@ -36,10 +40,13 @@ const SokSosialhjelpEngelsk: React.FC = () => {
     const [lesMer, setLesMer] = useState<boolean>(false);
 
     const tilgjengeligeKommunerService = useTilgjengeligeKommunerService();
+    const kommuneNrService = useKommuneNrService();
 
     let antallTilgjengeligKommuner: string = "";
     if (tilgjengeligeKommunerService.restStatus === REST_STATUS.OK) {
-        antallTilgjengeligKommuner = tilgjengeligeKommunerService.payload.results.length.toString();
+        antallTilgjengeligKommuner = antallKommuner(
+            tilgjengeligeKommunerService.payload.results
+        );
     }
 
     return (
@@ -112,23 +119,51 @@ const SokSosialhjelpEngelsk: React.FC = () => {
                         <UnmountClosed isOpened={lesMer}>
                             <KommuneSok
                                 ledetekst="Check if you can apply digitally in your municipality"
-                                soknadTilgjengeligTekst="You can apply digitally in "
-                                soknadIkkeTilgjengelig={
-                                    <span>
-                                        is unfortunately not yet able to accept
-                                        digital applications. You can apply
-                                        using the{" "}
+                                soknadOgInnsynTilgjengeligTekst={
+                                    <>
+                                        You can apply digitally in{" "}
+                                        {valgtKommuneNavn}. You can also follow
+                                        the{" "}
+                                        <Lenke href="https://www.nav.no/sosialhjelp/innsyn">
+                                            status of your application
+                                        </Lenke>{" "}
+                                        online.
+                                    </>
+                                }
+                                soknadTilgjengeligUtenInnsynTekst={
+                                    <>
+                                        You can apply digitally in{" "}
+                                        {valgtKommuneNavn}. Soon you will also
+                                        be able to follow the{" "}
+                                        <InternLenke href="./status-soknad?lang=en">
+                                            status of your application
+                                        </InternLenke>{" "}
+                                        online.
+                                    </>
+                                }
+                                soknadIkkeTilgjengeligTekst={
+                                    <>
+                                        {valgtKommuneNavn} is unfortunately not
+                                        yet able to accept digital applications.
+                                        You can apply using the{" "}
                                         <Lenke href={"./sok-papir?lang=en"}>
                                             municipality's own paper form
                                         </Lenke>
                                         .
-                                    </span>
+                                    </>
                                 }
                                 placeholderTekst="Enter municipality name"
                                 ariaLabel="Search for municipality"
+                                tilgjengeligeKommunerService={
+                                    tilgjengeligeKommunerService
+                                }
+                                kommuneNrService={kommuneNrService}
                                 onValgtKommune={(
                                     kommuneId: string | undefined
                                 ) => setKommuneId(kommuneId)}
+                                setValgtKommuneNavn={(kommuneNavn: string) =>
+                                    setValgtKommuneNavn(kommuneNavn)
+                                }
                             />
                         </UnmountClosed>
 

--- a/src/artikler/sok-sosialhjelp/SokSosialhjelpEngelskForskudd.tsx
+++ b/src/artikler/sok-sosialhjelp/SokSosialhjelpEngelskForskudd.tsx
@@ -14,6 +14,8 @@ import {UnmountClosed} from "react-collapse";
 import useTilgjengeligeKommunerService from "./komponenter/kommunesok/service/useTilgjengeligeKommunerService";
 import AapneLukkeLenke from "./komponenter/aapneLukkeLenke/AapneLukkeLenke";
 import {ANTALL_KOMMUNER} from "./SokSosialhjelp";
+import useKommuneNrService from "./komponenter/kommunesok/service/useKommuneNrService";
+import {InternLenke} from "../../komponenter/InternLenke";
 
 const AdvarselNedetid: React.FC<{nedetidService: any}> = ({nedetidService}) => {
     return (
@@ -32,6 +34,7 @@ const AdvarselNedetid: React.FC<{nedetidService: any}> = ({nedetidService}) => {
 
 const SokSosialhjelpEngelskForskudd: React.FC = () => {
     const [kommuneId, setKommuneId] = useState<string | undefined>(undefined);
+    const [valgtKommuneNavn, setValgtKommuneNavn] = useState("");
     const nedetidService = useNedetidService();
 
     const sokDigital = (event: any) => {
@@ -42,6 +45,7 @@ const SokSosialhjelpEngelskForskudd: React.FC = () => {
     const [lesMer, setLesMer] = useState<boolean>(false);
 
     const tilgjengeligeKommunerService = useTilgjengeligeKommunerService();
+    const kommuneNrService = useKommuneNrService();
 
     let antallTilgjengeligKommuner: string = "";
     if (tilgjengeligeKommunerService.restStatus === REST_STATUS.OK) {
@@ -80,28 +84,54 @@ const SokSosialhjelpEngelskForskudd: React.FC = () => {
                             )}
                         </Normaltekst>
                         <UnmountClosed isOpened={lesMer}>
-                            <div className="kommunesok_midlertidig">
-                                <KommuneSok
-                                    ledetekst="Check if you can apply digitally in your municipality"
-                                    soknadTilgjengeligTekst="You can apply digitally in "
-                                    soknadIkkeTilgjengelig={
-                                        <span>
-                                            is unfortunately not able to accept
-                                            digital applications. You can apply
-                                            using the municipality's own{" "}
-                                            <Lenke href={"./sok-papir?lang=nb"}>
-                                                paper form
-                                            </Lenke>
-                                            .
-                                        </span>
-                                    }
-                                    placeholderTekst="Enter municipality name"
-                                    ariaLabel="Search for municipality"
-                                    onValgtKommune={(
-                                        kommuneId: string | undefined
-                                    ) => setKommuneId(kommuneId)}
-                                />
-                            </div>
+                            <KommuneSok
+                                ledetekst="Check if you can apply digitally in your municipality"
+                                soknadOgInnsynTilgjengeligTekst={
+                                    <>
+                                        You can apply digitally in{" "}
+                                        {valgtKommuneNavn}. You can also follow
+                                        the{" "}
+                                        <Lenke href="https://www.nav.no/sosialhjelp/innsyn">
+                                            status of your application
+                                        </Lenke>{" "}
+                                        online.
+                                    </>
+                                }
+                                soknadTilgjengeligUtenInnsynTekst={
+                                    <>
+                                        You can apply digitally in{" "}
+                                        {valgtKommuneNavn}. Soon you will also
+                                        be able to follow the{" "}
+                                        <InternLenke href="./status-soknad?lang=en">
+                                            status of your application
+                                        </InternLenke>{" "}
+                                        online.
+                                    </>
+                                }
+                                soknadIkkeTilgjengeligTekst={
+                                    <>
+                                        {valgtKommuneNavn} is unfortunately not
+                                        yet able to accept digital applications.
+                                        You can apply using the{" "}
+                                        <Lenke href={"./sok-papir?lang=en"}>
+                                            municipality's own paper form
+                                        </Lenke>
+                                        .
+                                    </>
+                                }
+                                placeholderTekst="Enter municipality name"
+                                ariaLabel="Search for municipality"
+                                tilgjengeligeKommunerService={
+                                    tilgjengeligeKommunerService
+                                }
+                                kommuneNrService={kommuneNrService}
+                                onValgtKommune={(
+                                    kommuneId: string | undefined
+                                ) => setKommuneId(kommuneId)}
+                                setValgtKommuneNavn={(kommuneNavn: string) =>
+                                    setValgtKommuneNavn(kommuneNavn)
+                                }
+                            />
                         </UnmountClosed>
                         <Normaltekst>
                             <AapneLukkeLenke

--- a/src/artikler/sok-sosialhjelp/SokSosialhjelpNynorsk.tsx
+++ b/src/artikler/sok-sosialhjelp/SokSosialhjelpNynorsk.tsx
@@ -17,15 +17,19 @@ import AlertStripe from "nav-frontend-alertstriper";
 import useNedetidService from "./komponenter/kommunesok/service/useNedetidService";
 import {REST_STATUS} from "../../utils/restUtils";
 import Lenke from "nav-frontend-lenker";
-import useTilgjengeligeKommunerService from "./komponenter/kommunesok/service/useTilgjengeligeKommunerService";
+import useTilgjengeligeKommunerService, {
+    antallKommuner,
+} from "./komponenter/kommunesok/service/useTilgjengeligeKommunerService";
 import AapneLukkeLenke from "./komponenter/aapneLukkeLenke/AapneLukkeLenke";
 import {UnmountClosed} from "react-collapse";
 import {ANTALL_KOMMUNER} from "./SokSosialhjelp";
 import {Avsnitt} from "../../komponenter/avsnitt/Avsnitt";
 import {InternLenke} from "../../komponenter/InternLenke";
+import useKommuneNrService from "./komponenter/kommunesok/service/useKommuneNrService";
 
 const SokSosialhjelpNynorsk: React.FC = () => {
     const [kommuneId, setKommuneId] = useState<string | undefined>(undefined);
+    const [valgtKommuneNavn, setValgtKommuneNavn] = useState("");
     const nedetidService = useNedetidService();
 
     const sokDigital = (event: any) => {
@@ -36,9 +40,13 @@ const SokSosialhjelpNynorsk: React.FC = () => {
     const [lesMer, setLesMer] = useState<boolean>(false);
 
     const tilgjengeligeKommunerService = useTilgjengeligeKommunerService();
+    const kommuneNrService = useKommuneNrService();
+
     let antallTilgjengeligKommuner: string = "";
     if (tilgjengeligeKommunerService.restStatus === REST_STATUS.OK) {
-        antallTilgjengeligKommuner = tilgjengeligeKommunerService.payload.results.length.toString();
+        antallTilgjengeligKommuner = antallKommuner(
+            tilgjengeligeKommunerService.payload.results
+        );
     }
 
     return (
@@ -109,22 +117,49 @@ const SokSosialhjelpNynorsk: React.FC = () => {
                         <UnmountClosed isOpened={lesMer}>
                             <KommuneSok
                                 ledetekst="Sjekk om du kan søkje digitalt i din kommune"
-                                soknadTilgjengeligTekst="Du kan søkje digitalt i"
-                                soknadIkkeTilgjengelig={
-                                    <span>
-                                        kan dessverre ikkje ta i mot digitale
-                                        søknader enno. Du kan{" "}
+                                soknadOgInnsynTilgjengeligTekst={
+                                    <>
+                                        Du kan søkje digitalt i{" "}
+                                        {valgtKommuneNavn}. Du kan også følge{" "}
+                                        <Lenke href="https://www.nav.no/sosialhjelp/innsyn">
+                                            status på søknaden
+                                        </Lenke>{" "}
+                                        din på nav.no.
+                                    </>
+                                }
+                                soknadTilgjengeligUtenInnsynTekst={
+                                    <>
+                                        Du kan søkje digitalt i{" "}
+                                        {valgtKommuneNavn}. Snart kan du også
+                                        følge{" "}
+                                        <InternLenke href="/status-soknad?lang=nn">
+                                            status på søknaden
+                                        </InternLenke>{" "}
+                                        din på nav.no.
+                                    </>
+                                }
+                                soknadIkkeTilgjengeligTekst={
+                                    <>
+                                        Du kan dessverre ikkje søkje digitalt i{" "}
+                                        {valgtKommuneNavn} enno. Du kan{" "}
                                         <Lenke href={"./sok-papir?lang=nn"}>
                                             søkje på papirskjema
                                         </Lenke>
                                         .
-                                    </span>
+                                    </>
                                 }
                                 placeholderTekst="Skriv kommunenavn"
                                 ariaLabel="Søk etter kommunenavn"
+                                tilgjengeligeKommunerService={
+                                    tilgjengeligeKommunerService
+                                }
+                                kommuneNrService={kommuneNrService}
                                 onValgtKommune={(
                                     kommuneId: string | undefined
                                 ) => setKommuneId(kommuneId)}
+                                setValgtKommuneNavn={(kommuneNavn: string) =>
+                                    setValgtKommuneNavn(kommuneNavn)
+                                }
                             />
                         </UnmountClosed>
                         <Normaltekst>

--- a/src/artikler/sok-sosialhjelp/SokSosialhjelpNynorskForskudd.tsx
+++ b/src/artikler/sok-sosialhjelp/SokSosialhjelpNynorskForskudd.tsx
@@ -15,6 +15,8 @@ import HjelpeVideo from "./komponenter/hjelpevideo/HjelpeVideo";
 import AapneLukkeLenke from "./komponenter/aapneLukkeLenke/AapneLukkeLenke";
 import useTilgjengeligeKommunerService from "./komponenter/kommunesok/service/useTilgjengeligeKommunerService";
 import {ANTALL_KOMMUNER} from "./SokSosialhjelp";
+import useKommuneNrService from "./komponenter/kommunesok/service/useKommuneNrService";
+import {InternLenke} from "../../komponenter/InternLenke";
 
 const AdvarselNedetid: React.FC<{nedetidService: any}> = ({nedetidService}) => {
     return (
@@ -33,6 +35,7 @@ const AdvarselNedetid: React.FC<{nedetidService: any}> = ({nedetidService}) => {
 
 const SokSosialhjelpNynorskForskudd: React.FC = () => {
     const [kommuneId, setKommuneId] = useState<string | undefined>(undefined);
+    const [valgtKommuneNavn, setValgtKommuneNavn] = useState("");
     const nedetidService = useNedetidService();
 
     const sokDigital = (event: any) => {
@@ -43,6 +46,8 @@ const SokSosialhjelpNynorskForskudd: React.FC = () => {
     const [lesMer, setLesMer] = useState<boolean>(false);
 
     const tilgjengeligeKommunerService = useTilgjengeligeKommunerService();
+    const kommuneNrService = useKommuneNrService();
+
     let antallTilgjengeligKommuner: string = "";
     if (tilgjengeligeKommunerService.restStatus === REST_STATUS.OK) {
         antallTilgjengeligKommuner = tilgjengeligeKommunerService.payload.results.length.toString();
@@ -80,27 +85,52 @@ const SokSosialhjelpNynorskForskudd: React.FC = () => {
                             )}
                         </Normaltekst>
                         <UnmountClosed isOpened={lesMer}>
-                            <div className="kommunesok_midlertidig">
-                                <KommuneSok
-                                    ledetekst="Sjekk om du kan søkje digitalt i din kommune"
-                                    soknadTilgjengeligTekst="Du kan søke digitalt i"
-                                    soknadIkkeTilgjengelig={
-                                        <span>
-                                            kan dessverre ikkje ta i mot
-                                            digitale søknader enno. Du kan{" "}
-                                            <Lenke href={"./sok-papir?lang=nb"}>
-                                                søkje på papirskjema
-                                            </Lenke>
-                                            .
-                                        </span>
-                                    }
-                                    placeholderTekst="Skriv kommunenavn"
-                                    ariaLabel="Søk etter kommunenavn"
-                                    onValgtKommune={(
-                                        kommuneId: string | undefined
-                                    ) => setKommuneId(kommuneId)}
-                                />
-                            </div>
+                            <KommuneSok
+                                ledetekst="Sjekk om du kan søkje digitalt i din kommune"
+                                soknadOgInnsynTilgjengeligTekst={
+                                    <>
+                                        Du kan søkje digitalt i{" "}
+                                        {valgtKommuneNavn}. Du kan også følge{" "}
+                                        <Lenke href="https://www.nav.no/sosialhjelp/innsyn">
+                                            status på søknaden
+                                        </Lenke>{" "}
+                                        din på nav.no.
+                                    </>
+                                }
+                                soknadTilgjengeligUtenInnsynTekst={
+                                    <>
+                                        Du kan søkje digitalt i{" "}
+                                        {valgtKommuneNavn}. Snart kan du også
+                                        følge{" "}
+                                        <InternLenke href="/status-soknad?lang=nn">
+                                            status på søknaden
+                                        </InternLenke>{" "}
+                                        din på nav.no.
+                                    </>
+                                }
+                                soknadIkkeTilgjengeligTekst={
+                                    <>
+                                        Du kan dessverre ikkje søkje digitalt i{" "}
+                                        {valgtKommuneNavn} enno. Du kan{" "}
+                                        <Lenke href={"./sok-papir?lang=nn"}>
+                                            søkje på papirskjema
+                                        </Lenke>
+                                        .
+                                    </>
+                                }
+                                placeholderTekst="Skriv kommunenavn"
+                                ariaLabel="Søk etter kommunenavn"
+                                tilgjengeligeKommunerService={
+                                    tilgjengeligeKommunerService
+                                }
+                                kommuneNrService={kommuneNrService}
+                                onValgtKommune={(
+                                    kommuneId: string | undefined
+                                ) => setKommuneId(kommuneId)}
+                                setValgtKommuneNavn={(kommuneNavn: string) =>
+                                    setValgtKommuneNavn(kommuneNavn)
+                                }
+                            />
                         </UnmountClosed>
                         <Normaltekst>
                             <AapneLukkeLenke

--- a/src/artikler/sok-sosialhjelp/komponenter/kommunesok/Kommunesok.tsx
+++ b/src/artikler/sok-sosialhjelp/komponenter/kommunesok/Kommunesok.tsx
@@ -67,7 +67,6 @@ const KommuneSok: React.FC<Props> = ({
             );
             if (kommuneErTilgjengelig) {
                 onValgtKommune(suggestion.key);
-                console.log("currentSuggestion", suggestion.value);
             } else {
                 onValgtKommune(undefined);
             }

--- a/src/artikler/sok-sosialhjelp/komponenter/kommunesok/Kommunesok.tsx
+++ b/src/artikler/sok-sosialhjelp/komponenter/kommunesok/Kommunesok.tsx
@@ -1,68 +1,84 @@
 import * as React from "react";
 import NavAutocomplete, {Suggestion} from "./navAutocomplete/NavAutcomplete";
 import {useState} from "react";
-import useKommuneNrService from "./service/useKommuneNrService";
+import {KommuneNummere} from "./service/useKommuneNrService";
 import {REST_STATUS} from "../../../../utils/restUtils";
-import useTilgjengeligeKommunerService, {
+import {
     finnTilgjengeligKommune,
+    TilgjengeligeKommuner,
 } from "./service/useTilgjengeligeKommunerService";
 import "./kommunesok.less";
 import {Normaltekst} from "nav-frontend-typografi";
+import NavFrontendSpinner from "nav-frontend-spinner";
+import {ServiceHookTypes} from "./service/ServiceHookTypes";
 
 interface Props {
     ledetekst: string;
-    soknadTilgjengeligTekst: string;
-    soknadIkkeTilgjengeligTekst?: string;
-    soknadIkkeTilgjengelig?: React.ReactNode;
+    soknadOgInnsynTilgjengeligTekst: React.ReactNode;
+    soknadTilgjengeligUtenInnsynTekst: React.ReactNode;
+    soknadIkkeTilgjengeligTekst: React.ReactNode;
     placeholderTekst: string;
     ariaLabel: string;
+    tilgjengeligeKommunerService: ServiceHookTypes<TilgjengeligeKommuner>;
+    kommuneNrService: ServiceHookTypes<KommuneNummere>;
     onValgtKommune: (kommuneId: string | undefined) => void;
+    setValgtKommuneNavn: (kommuneNavn: string) => void;
 }
 
 const KommuneSok: React.FC<Props> = ({
     ledetekst,
-    soknadTilgjengeligTekst,
+    soknadOgInnsynTilgjengeligTekst,
+    soknadTilgjengeligUtenInnsynTekst,
     soknadIkkeTilgjengeligTekst,
-    soknadIkkeTilgjengelig,
     placeholderTekst,
     ariaLabel,
+    tilgjengeligeKommunerService,
+    kommuneNrService,
     onValgtKommune,
+    setValgtKommuneNavn,
 }) => {
     const [
         currentSuggestion,
         setCurrentSuggestion,
     ] = useState<Suggestion | null>(null);
-    const [soknadTilgjengelig, setSoknadTilgjengelig] = useState<boolean>(
-        false
-    );
-    const kommunerService = useKommuneNrService();
-    const tilgjengeligeKommunerService = useTilgjengeligeKommunerService();
+    const [kommuneHarSoknad, setKommuneHarSoknad] = useState(false);
+    const [kommuneHarInnsyn, setKommuneHarInnsyn] = useState(false);
 
     const onReset = () => {
         setCurrentSuggestion(null);
-        setSoknadTilgjengelig(false);
+        setKommuneHarSoknad(false);
+        setKommuneHarInnsyn(false);
     };
 
     const onSelect = (suggestion: Suggestion) => {
         onReset();
         if (tilgjengeligeKommunerService.restStatus === REST_STATUS.OK) {
-            let kommuneErTilgjengelig: boolean = finnTilgjengeligKommune(
+            const tilgjengeligKommune = finnTilgjengeligKommune(
                 tilgjengeligeKommunerService.payload.results,
                 suggestion.key
             );
-            setSoknadTilgjengelig(kommuneErTilgjengelig);
+            const kommuneErTilgjengelig: boolean =
+                tilgjengeligKommune !== undefined &&
+                tilgjengeligKommune.kanMottaSoknader;
+            setKommuneHarSoknad(kommuneErTilgjengelig);
+            setKommuneHarInnsyn(
+                tilgjengeligKommune !== undefined &&
+                    tilgjengeligKommune.kanOppdatereStatus
+            );
             if (kommuneErTilgjengelig) {
                 onValgtKommune(suggestion.key);
+                console.log("currentSuggestion", suggestion.value);
             } else {
                 onValgtKommune(undefined);
             }
         }
+        setValgtKommuneNavn(suggestion.value);
         setCurrentSuggestion(suggestion);
     };
 
     const suggestions: Suggestion[] =
-        kommunerService.restStatus === REST_STATUS.OK
-            ? kommunerService.payload.results
+        kommuneNrService.restStatus === REST_STATUS.OK
+            ? kommuneNrService.payload.results
             : [];
 
     return (
@@ -71,34 +87,46 @@ const KommuneSok: React.FC<Props> = ({
                 <b>{ledetekst}</b>
             </Normaltekst>
             <br />
-            <NavAutocomplete
-                placeholder={placeholderTekst}
-                suggestions={suggestions}
-                ariaLabel={ariaLabel}
-                id="kommunesok"
-                onSelect={(suggestion: Suggestion) => onSelect(suggestion)}
-                onReset={() => onReset()}
-            />
-            {currentSuggestion && soknadTilgjengelig && (
+            {kommuneNrService.restStatus === REST_STATUS.OK &&
+            tilgjengeligeKommunerService.restStatus === REST_STATUS.OK ? (
+                <NavAutocomplete
+                    placeholder={placeholderTekst}
+                    suggestions={suggestions}
+                    ariaLabel={ariaLabel}
+                    id="kommunesok"
+                    onSelect={(suggestion: Suggestion) => onSelect(suggestion)}
+                    onReset={() => onReset()}
+                />
+            ) : (
+                <NavFrontendSpinner />
+            )}
+            {currentSuggestion && kommuneHarSoknad && kommuneHarInnsyn && (
                 <div style={{textAlign: "left", paddingTop: "1rem"}}>
                     <div className="kommunesok_tilbakemelding ">
                         <Normaltekst>
-                            {soknadTilgjengeligTekst} {currentSuggestion.value}
+                            {soknadOgInnsynTilgjengeligTekst}
                         </Normaltekst>
                     </div>
                 </div>
             )}
-            {!soknadTilgjengelig && currentSuggestion && (
+            {currentSuggestion && kommuneHarSoknad && !kommuneHarInnsyn && (
+                <div style={{textAlign: "left", paddingTop: "1rem"}}>
+                    <div className="kommunesok_tilbakemelding ">
+                        <Normaltekst>
+                            {soknadTilgjengeligUtenInnsynTekst}
+                        </Normaltekst>
+                    </div>
+                </div>
+            )}
+            {!kommuneHarSoknad && currentSuggestion && (
                 <div style={{textAlign: "left", paddingTop: "1rem"}}>
                     <div
                         className="kommunesok_tilbakemelding "
                         style={{paddingTop: "0.5rem", marginBottom: "0"}}
                     >
                         <Normaltekst>
-                            {currentSuggestion.value}{" "}
                             {soknadIkkeTilgjengeligTekst &&
                                 soknadIkkeTilgjengeligTekst}
-                            {soknadIkkeTilgjengelig && soknadIkkeTilgjengelig}
                         </Normaltekst>
                     </div>
                 </div>

--- a/src/artikler/sok-sosialhjelp/komponenter/kommunesok/service/useTilgjengeligeKommunerService.ts
+++ b/src/artikler/sok-sosialhjelp/komponenter/kommunesok/service/useTilgjengeligeKommunerService.ts
@@ -90,7 +90,6 @@ const useTilgjengeligeKommunerService = (): ServiceHookTypes<
                 setResult({restStatus: REST_STATUS.FEILET, error})
             );
     }, [url]);
-    console.log("result", result);
     return result;
 };
 
@@ -98,11 +97,9 @@ const finnTilgjengeligKommune = (
     tilgjengeligeKommuner: {[key: string]: KommuneInfo},
     kommunenummer: string
 ): KommuneInfo | undefined => {
-    const tilgjengeligKommune = Object.values(
-        tilgjengeligeKommuner
-    ).filter((kommune) => kommune.kommunenummer.match(kommunenummer));
-
-    return tilgjengeligKommune[0];
+    return Object.values(tilgjengeligeKommuner)
+        .filter((kommune) => kommune.kommunenummer.match(kommunenummer))
+        .shift();
 };
 
 export const antallKommuner = (tilgjengeligeKommuner: {

--- a/src/index.less
+++ b/src/index.less
@@ -76,3 +76,7 @@ a:not(.knapp).no-text-decoration {
 .decorator-utils-container {
     background: #ffffff;
 }
+
+.footer-bottom-content__del-skjerm {
+    display: none !important;
+}

--- a/src/index.less
+++ b/src/index.less
@@ -77,6 +77,7 @@ a:not(.knapp).no-text-decoration {
     background: #ffffff;
 }
 
+// Hack for å skjule del-skjerm knappen
 .footer-bottom-content__del-skjerm {
     display: none !important;
 }


### PR DESCRIPTION
Avhenger av https://github.com/navikt/sosialhjelp-soknad-api/pull/449 som må prodsettes først.

Tar i bruk nytt endepunkt fra soknad-api som returnerer kommuneinfo fremfor bare kommunummer for kommuner som er påkoblet.

Har også trukket logikken for å hente kommuneinfo og data fra kartverket ut fra kommunesøk, slik at disse ikke lastes hver gang kommunesøket åpnes. La også på en spinner i stedet for inputfelt så lenge data lastes inn, slik at bruker ikke får feilmelding hvis de er for raske med å skrive inn kommune.