### PR TITLE
La kommunesøket retrurnere den første i listen dersom det er flere resultater

### DIFF
--- a/src/artikler/sok-sosialhjelp/komponenter/kommunesok/navAutocomplete/NavAutcomplete.tsx
+++ b/src/artikler/sok-sosialhjelp/komponenter/kommunesok/navAutocomplete/NavAutcomplete.tsx
@@ -93,34 +93,14 @@ const NavAutocomplete: React.FC<Props> = ({
                 }
                 break;
             case KEY.ENTER:
-                if (displayedSuggestions.length === 0) {
+                if (displayedSuggestions.length < 1) {
                     onReset && onReset();
                     setHasErrors(true);
-                }
-                if (displayedSuggestions.length === 1) {
-                    const displayedSuggestions: Suggestion[] = searchSuggestions(
-                        suggestions,
-                        value
-                    );
-                    event.preventDefault(); // Unngå form submit når bruker velger et av forslagene
-                    setValue(displayedSuggestions[0].value);
-                    onClick(displayedSuggestions[0]);
                 } else {
-                    if (hasSelectedSuggestion && shouldShowSuggestions) {
-                        const displayedSuggestions: Suggestion[] = searchSuggestions(
-                            suggestions,
-                            value
-                        );
-                        event.preventDefault(); // Unngå form submit når bruker velger et av forslagene
-                        setValue(
-                            displayedSuggestions[activeSuggestionIndex].value
-                        );
-                        onClick(displayedSuggestions[activeSuggestionIndex]);
-                    } else {
-                        onReset && onReset();
-                        setHasErrors(true);
-                        setShouldShowSuggestions(false);
-                    }
+                    event.preventDefault(); // Unngå form submit når bruker velger et av forslagene
+                    const suggestionIndex = activeSuggestionIndex >= 0 ? activeSuggestionIndex : 0;
+                    setValue(displayedSuggestions[suggestionIndex].value);
+                    onClick(displayedSuggestions[suggestionIndex]);
                 }
                 break;
             case KEY.ESC:

--- a/src/utils/restUtils.ts
+++ b/src/utils/restUtils.ts
@@ -1,6 +1,6 @@
 export function erDev(): boolean {
     const url = window.location.href;
-    return url.indexOf("localhost:3000") > 0;
+    return url.indexOf("localhost") > 0;
 }
 
 export function erQ(): boolean {


### PR DESCRIPTION
Dette løser problemet der bruker skriver "heim" men dette får flere resultater: "Heim", "Trondheim" og "Austerheim". Før denne fiksen ville et trykk på enter etter å ha skrevet "heim" gi feilmeldingen: "Vi fant ikke denne kommunen, vennligst sjekk at du har skrevet det riktig". Etter denne fiksen vil et trykk på enter gi den første kommunen.
Kommunesøket er såppas smart at det gir det "beste" resultatet øverst.

Fjerner også :3000 fra localhost-sjekk, slik at den også fungerer om man kjører på en annen port.