### PR TITLE
Bytter ut onClick metode med linkCreator i LenkePanelBase

### DIFF
--- a/src/artikler/forside/komponenter/SokOmSosialhjelpPanel.tsx
+++ b/src/artikler/forside/komponenter/SokOmSosialhjelpPanel.tsx
@@ -3,24 +3,23 @@ import {LenkepanelBase} from "nav-frontend-lenkepanel/lib";
 import {Systemtittel} from "nav-frontend-typografi";
 import "./sokOmSosialhjelpPanel.less";
 import IllustrasjonsGruppe from "../../../komponenter/bilder/IllustrasjonsGruppe";
-import {useHistory} from "react-router-dom";
+import {NavLink} from "react-router-dom";
 
 const SokOmSosialhjelpPanel: React.FC<{
     href: string;
     children: React.ReactNode;
 }> = ({href, children}) => {
-    const history = useHistory();
-
-    const onClick = (href: string, event: any) => {
-        history.push(href);
-        event.preventDefault();
-    };
-
     return (
         <LenkepanelBase
-            className="start_soknad_panel"
+            linkCreator={(props) => (
+                <NavLink
+                    className="start_soknad_panel lenkepanel"
+                    to={props.href ?? ""}
+                >
+                    {props.children}
+                </NavLink>
+            )}
             href={href}
-            onClick={(event: any) => onClick(event, href)}
         >
             <div className="sokMobilIllustrasjon" />
 


### PR DESCRIPTION
Dette er den foretrukne måten å bruke custom elementer for routing i `LenkePanel` jf. kodeeksempler for nav-frontend https://github.com/navikt/nav-frontend-moduler-2-poc/blob/master/website/src/ui/containers/get-started/GetStartedPage.js