### PR TITLE
Legger til scrollTo-støtte for gamle nettlesere som ikke støtter scrollTo med objekt som parameter

### DIFF
--- a/src/artikler/Artikkel.tsx
+++ b/src/artikler/Artikkel.tsx
@@ -34,10 +34,14 @@ const Artikkel: React.FC<Props> = ({
     useDecorator(breadcrumbPages);
 
     useEffect(() => {
-        window.scrollTo({
-            behavior: "smooth",
-            top: 0,
-        });
+        const supportsNativeSmoothScroll =
+            "scrollBehavior" in document.documentElement.style;
+        supportsNativeSmoothScroll
+            ? window.scrollTo({
+                  behavior: "smooth",
+                  top: 0,
+              })
+            : window.scrollTo(0, 0);
     }, [pathname]);
 
     return (


### PR DESCRIPTION
Vi får en god del feilmeldinger i Sentry fra gamle nettlesere som forventer to tall som parameter til `scrollTo` funksjonen. Med denne fiksen vil disse nettleserene få scroll til toppen av siden, men uten "smooth" scroll som nyere nettlesere støtter. Ref https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo