### PR TITLE
Error handling sanity

### DIFF
--- a/src/artikler/SanityArtikkel.tsx
+++ b/src/artikler/SanityArtikkel.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as Sentry from "@sentry/browser";
 import {Innholdstittel} from "nav-frontend-typografi";
 import Artikkel from "./Artikkel";
 import {SanityBlockContent} from "../komponenter/SanityBlockContent";
@@ -10,13 +11,26 @@ import {Lastestriper} from "../komponenter/Lastestriper";
 
 const SanityArtikkel = (props: {slug: string; locale: "nb" | "nn" | "en"}) => {
     const [article, setArticle] = React.useState<SanityArticle>();
+    const [hasErros, setHasErrors] = React.useState(false);
     React.useEffect(() => {
-        fetchArticleWithSlugAndLocale(props.slug, props.locale).then(
-            (article) => {
+        fetchArticleWithSlugAndLocale(props.slug, props.locale)
+            .then((article) => {
                 setArticle(article);
-            }
-        );
+            })
+            .catch((e) => {
+                setHasErrors(true);
+                Sentry.captureException(e);
+            });
     }, [props.slug, props.locale, setArticle]);
+
+    if (hasErros) {
+        return (
+            <Artikkel tittel="Det har oppstått en feil">
+                <Innholdstittel>Det har oppstått en feil</Innholdstittel>
+                Du kan laste siden på nytt, eller prøve igjen senere.
+            </Artikkel>
+        );
+    }
 
     if (!article) {
         return (

--- a/src/artikler/SanityArtikkel.tsx
+++ b/src/artikler/SanityArtikkel.tsx
@@ -12,9 +12,15 @@ import {Lastestriper} from "../komponenter/Lastestriper";
 const SanityArtikkel = (props: {slug: string; locale: "nb" | "nn" | "en"}) => {
     const [article, setArticle] = React.useState<SanityArticle>();
     const [hasErros, setHasErrors] = React.useState(false);
+    const [notFound, setNotFound] = React.useState(false);
+
     React.useEffect(() => {
         fetchArticleWithSlugAndLocale(props.slug, props.locale)
             .then((article) => {
+                if (Object.keys(article).length === 0) {
+                    setNotFound(true);
+                }
+                console.log("article", article);
                 setArticle(article);
             })
             .catch((e) => {
@@ -28,6 +34,14 @@ const SanityArtikkel = (props: {slug: string; locale: "nb" | "nn" | "en"}) => {
             <Artikkel tittel="Det har oppstått en feil">
                 <Innholdstittel>Det har oppstått en feil</Innholdstittel>
                 Du kan laste siden på nytt, eller prøve igjen senere.
+            </Artikkel>
+        );
+    }
+
+    if (notFound) {
+        return (
+            <Artikkel tittel="Denne siden finnes ikke">
+                <Innholdstittel>Denne siden finnes ikke</Innholdstittel>
             </Artikkel>
         );
     }


### PR DESCRIPTION
Har lagt til enkel error-handling ved spørring mot Sanity, slik at vi får muligheten til å vise informasjon til bruker dersom vi ikke klarer å laste inn data (eks Sanity er nede) eller de har navigert til en side som ikke finnes (Sanity returnerer et tomt objekt for spørringer på data som ikke finnes).

Tekstene må avklares / kvalitetssikres før vi går i prod med Sanity.