### PR TITLE
Viser feilmeldinger for 'ikke funnet' og 'oppstått feil' situasjoner i veiviseren

### DIFF
--- a/src/artikler/SanityArtikkel.tsx
+++ b/src/artikler/SanityArtikkel.tsx
@@ -38,14 +38,14 @@ const SanityArtikkel = (props: {slug: string; locale: "nb" | "nn" | "en"}) => {
                 <Normaltekst>
                     Du kan laste siden på nytt,{" "}
                     <Lenke href="https://www.nav.no/">gå til forsiden</Lenke>,
-                    eller prøve igjen senere .
+                    eller prøve igjen senere.
                 </Normaltekst>
 
                 <Undertittel>In English</Undertittel>
                 <Normaltekst>
-                    An error occured. You can try to refresh the page, Go to the{" "}
-                    <Lenke href="https://www.nav.no/">front page</Lenke>, or try
-                    again later.
+                    An error occurred. You can try to refresh the page, go to
+                    the <Lenke href="https://www.nav.no/">front page</Lenke>, or
+                    try again later.
                 </Normaltekst>
             </Artikkel>
         );

--- a/src/artikler/SanityArtikkel.tsx
+++ b/src/artikler/SanityArtikkel.tsx
@@ -43,7 +43,7 @@ const SanityArtikkel = (props: {slug: string; locale: "nb" | "nn" | "en"}) => {
 
                 <Undertittel>In English</Undertittel>
                 <Normaltekst>
-                    An error occured. You can try to reload the page, Go to the{" "}
+                    An error occured. You can try to refresh the page, Go to the{" "}
                     <Lenke href="https://www.nav.no/">front page</Lenke>, or try
                     again later.
                 </Normaltekst>

--- a/src/artikler/SanityArtikkel.tsx
+++ b/src/artikler/SanityArtikkel.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Sentry from "@sentry/browser";
-import {Innholdstittel} from "nav-frontend-typografi";
+import {Innholdstittel, Normaltekst, Undertittel} from "nav-frontend-typografi";
 import Artikkel from "./Artikkel";
 import {SanityBlockContent} from "../komponenter/SanityBlockContent";
 import {
@@ -8,6 +8,8 @@ import {
     SanityArticle,
 } from "../utils/sanityFetch";
 import {Lastestriper} from "../komponenter/Lastestriper";
+import Lenke from "nav-frontend-lenker";
+import {Link} from "react-router-dom";
 
 const SanityArtikkel = (props: {slug: string; locale: "nb" | "nn" | "en"}) => {
     const [article, setArticle] = React.useState<SanityArticle>();
@@ -33,15 +35,53 @@ const SanityArtikkel = (props: {slug: string; locale: "nb" | "nn" | "en"}) => {
         return (
             <Artikkel tittel="Det har oppstått en feil">
                 <Innholdstittel>Det har oppstått en feil</Innholdstittel>
-                Du kan laste siden på nytt, eller prøve igjen senere.
+                <Normaltekst>
+                    Du kan laste siden på nytt,{" "}
+                    <Lenke href="https://www.nav.no/">gå til forsiden</Lenke>,
+                    eller prøve igjen senere .
+                </Normaltekst>
+
+                <Undertittel>In English</Undertittel>
+                <Normaltekst>
+                    An error occured. You can try to reload the page, Go to the{" "}
+                    <Lenke href="https://www.nav.no/">front page</Lenke>, or try
+                    again later.
+                </Normaltekst>
             </Artikkel>
         );
     }
 
     if (notFound) {
         return (
-            <Artikkel tittel="Denne siden finnes ikke">
-                <Innholdstittel>Denne siden finnes ikke</Innholdstittel>
+            <Artikkel tittel="Fant ikke siden">
+                <Innholdstittel>Fant ikke siden</Innholdstittel>
+                <Normaltekst>
+                    Beklager, siden kan være slettet eller flyttet, eller det
+                    var en feil i lenken som førte deg hit.
+                </Normaltekst>
+                <Normaltekst>
+                    Du kan{" "}
+                    <Lenke href="https://www.nav.no/">gå til forsiden</Lenke>,
+                    eller lese mer om{" "}
+                    <Link to="/" className="lenke">
+                        økonomisk sosialhjelp
+                    </Link>
+                    .
+                </Normaltekst>
+
+                <Undertittel>In English</Undertittel>
+                <Normaltekst>
+                    The page you requested cannot be found.
+                </Normaltekst>
+                <Normaltekst>
+                    Go to the{" "}
+                    <Lenke href="https://www.nav.no/">front page</Lenke>, or
+                    read more about{" "}
+                    <Link to="/?lang=en" className="lenke">
+                        financial assistance
+                    </Link>
+                    .
+                </Normaltekst>
             </Artikkel>
         );
     }


### PR DESCRIPTION
"Ikke funnet" situasjonen er hvis spørring mot Sanity er OK, men responsen er tom. Da finnes det ikke noe dokument / artikkel.

"Det har oppstått en feil" vises dersom responsen fra Sanity ikke er OK. Eks spørringen har timet ut, det har oppstått nettverksfeil eller lignende.

![Screenshot 2021-03-26 at 09 02 21](https://user-images.githubusercontent.com/7832273/112602419-f0c69100-8e13-11eb-856f-65abd4b294a8.png)
![Screenshot 2021-03-26 at 08 59 10](https://user-images.githubusercontent.com/7832273/112602421-f1f7be00-8e13-11eb-8d92-58f8bb2d2d89.png)