### PR TITLE
Setter redirect serverside slik at vi kan avpublisere artikkel i vår app

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,6 +16,10 @@ app.set("views", `${__dirname}/build`);
 app.set("view engine", "mustache");
 app.engine("html", mustacheExpress());
 
+app.get(`${basePath}/hvis-du-er-enslig-forsorger`, (req, res) =>
+    res.redirect(301, "https://www.nav.no/familie/alene-med-barn")
+);
+
 app.use(basePath, express.static(buildPath, {index: false}));
 
 // Nais functions


### PR DESCRIPTION
Redirect blir gjort i Express som kjører på serversiden. Vi får da muligheten til å returnere en 301 statuskode, i stedet for at redirect blir gjort etter at appen er lastet inn og rendret i nettleser. 