### PR TITLE
Bruke samme helsesjekk i express og next

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -22,10 +22,10 @@ spec:
     enabled: {{prometheusEnabled}}
     path: /prometheus
   liveness:
-    path: /sosialhjelp/internal/isAlive
+    path: /sosialhjelp/api/isAlive
     initialDelay: 20
   readiness:
-    path: /sosialhjelp/internal/isReady
+    path: /sosialhjelp/api/isReady
     initialDelay: 20
   resources:
     limits:

--- a/pages/api/isAlive.ts
+++ b/pages/api/isAlive.ts
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+    res.status(200).json({});
+}

--- a/pages/api/isReady.ts
+++ b/pages/api/isReady.ts
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+    res.status(200).json({});
+}

--- a/server.js
+++ b/server.js
@@ -23,11 +23,9 @@ app.get(`${basePath}/hvis-du-er-enslig-forsorger`, (req, res) =>
 app.use(basePath, express.static(buildPath, {index: false}));
 
 // Nais functions
-app.get(`${basePath}/internal/isAlive|isReady`, (req, res) =>
-    res.sendStatus(200)
-);
+app.get(`${basePath}/api/isAlive|isReady`, (req, res) => res.sendStatus(200));
 
-app.use(/^(?!.*\/(internal|static)\/).*$/, (req, res) =>
+app.use(/^(?!.*\/(internal|api|static)\/).*$/, (req, res) =>
     res.render("index.html", {DECORATOR_URL: decoratorUrl})
 );
 


### PR DESCRIPTION
Default for API-endepunkter i nextjs er `/api`. Det er også dette vi bruker i øk. veiviser, så prøver å holde config så lik som mulig.