### PR TITLE
Legger til api-endepunkter for kommunesøk og nedetid

### DIFF
--- a/pages/api/kommuner.ts
+++ b/pages/api/kommuner.ts
@@ -1,0 +1,107 @@
+export default async function handler(req, res) {
+    await fetchKommuner()
+        .then((result) => {
+            res.status(200).json(result);
+        })
+        .catch(res.status(500));
+}
+
+export interface KommunerResponse {
+    totaltAntall: number;
+    antallAktivertSoknad: number;
+    kommuner: {
+        [kommuneNummer: string]: Kommune;
+    };
+}
+
+export interface Kommune {
+    kommuneNummer: string;
+    kommuneNavn: string;
+    kanMottaSoknader: boolean;
+    kanOppdatereStatus: boolean;
+}
+
+export const ANTALL_KOMMUNER = 356;
+
+export interface KommuneInfo {
+    kommuneNummer: string;
+    kanMottaSoknader: boolean;
+    kanOppdatereStatus: boolean;
+}
+
+export interface KommuneinfoResponse {
+    [kommuneNummer: string]: KommuneInfo;
+}
+
+export interface KommunenummerResponse {
+    containeditems: [
+        {
+            status: string;
+            description: string;
+            label: string;
+        }
+    ];
+}
+
+export interface KommuneNummer {
+    [kommuneNummer: string]: {
+        kommuneNummer: string;
+        kommuneNavn: string;
+    };
+}
+
+export async function fetchKommuner(): Promise<KommunerResponse> {
+    const kommuneinfoUrl =
+        "https://www.nav.no/sosialhjelp/soknad-api/informasjon/kommuneinfo";
+
+    const kommuneinfo: KommuneinfoResponse = await fetch(
+        kommuneinfoUrl
+    ).then((response) => response.json());
+
+    const kommunenrUrl =
+        "https://www.nav.no/sosialhjelp/innsyn-api/api/veiviser/kommunenummer";
+
+    const kommuner = await fetch(kommunenrUrl)
+        .then((response) => response.json())
+        .then((response: KommunenummerResponse) => {
+            return processKommunenummerResponse(response);
+        });
+
+    return {
+        totaltAntall: ANTALL_KOMMUNER,
+        antallAktivertSoknad: Object.values(kommuneinfo).filter(
+            (kommune) => kommune.kanMottaSoknader
+        ).length,
+        kommuner: Object.values(kommuner).reduce((accumulator, kommune) => {
+            const kommuneInfo = kommuneinfo[kommune.kommuneNummer];
+            return {
+                ...accumulator,
+                [kommune.kommuneNummer]: {
+                    kommuneNummer: kommune.kommuneNummer,
+                    kommuneNavn: kommune.kommuneNavn,
+                    kanMottaSoknader: kommuneInfo?.kanMottaSoknader ?? false,
+                    kanOppdatereStatus:
+                        kommuneInfo?.kanOppdatereStatus ?? false,
+                },
+            };
+        }, {}),
+    };
+}
+
+const processKommunenummerResponse = (
+    response: KommunenummerResponse
+): KommuneNummer => {
+    return response.containeditems
+        .filter((item) => {
+            return item.status === "Gyldig" || item.status === "Valid";
+        })
+        .reduce((accumulator, kommune) => {
+            return {
+                ...accumulator,
+                [kommune.label]: {
+                    kommuneNummer: kommune.label,
+                    kommuneNavn: kommune.description,
+                },
+            };
+        }, {});
+};

--- a/pages/api/nedetid.ts
+++ b/pages/api/nedetid.ts
@@ -1,0 +1,36 @@
+export default async function handler(req, res) {
+    await fetchNedetid()
+        .then((result) => {
+            res.status(200).json(result);
+        })
+        .catch(res.status(500));
+}
+
+export interface NedetidResponse {
+    isNedetid: boolean;
+    isPlanlagtNedetid: boolean;
+    nedetidStart: string;
+    nedetidSlutt: string;
+    nedetidStartText: string;
+    nedetidSluttText: string;
+    nedetidStartTextEn: string;
+    nedetidSluttTextEn: string;
+}
+
+export async function fetchNedetid(): Promise<NedetidResponse> {
+    const nedetidUrl = "https://www.nav.no/sosialhjelp/soknad-api/nedetid";
+    return await fetch(nedetidUrl)
+        .then((response) => response.json())
+        .then((json) => {
+            return {
+                isNedetid: json.isNedetid,
+                isPlanlagtNedetid: json.isPlanlagtNedetid,
+                nedetidStart: json.nedetidStart,
+                nedetidSlutt: json.nedetidSlutt,
+                nedetidStartText: json.nedetidStartText,
+                nedetidSluttText: json.nedetidSluttText,
+                nedetidStartTextEn: json.nedetidStartTextEn,
+                nedetidSluttTextEn: json.nedetidSluttTextEn,
+            };
+        });
+}


### PR DESCRIPTION
Eget api-endepunkt for kommunesøk som sammenstiller og maserer data fra soknad-api og kartverket, proxyer også kall mot nedetid endepunkt.

Data fra api-endepunktene kan også hentes ut med `getStaticProps` i next, slik at dataene vil være tilgjengelig ved bygg / generering av en side. Da slipper vi å gjøre flere fetch-kall i frontend og siden vil oppleves raskere for bruker.