### PR TITLE
Ekstra ca certs i sbs

### DIFF
--- a/nais/dev/dev-sbs-intern.json
+++ b/nais/dev/dev-sbs-intern.json
@@ -11,6 +11,7 @@
   "env": {
     "APPRES_CMS_URL": "https://appres-q1.nav.no",
     "FASIT_ENVIRONMENT_NAME": "q1",
-    "DECORATOR_URL": "https://dekoratoren.dev.nav.no"
+    "DECORATOR_URL": "https://dekoratoren.dev.nav.no",
+    "NODE_EXTRA_CA_CERTS": "/etc/ssl/ca-bundle.pem"
   }
 }

--- a/nais/dev/dev-sbs.json
+++ b/nais/dev/dev-sbs.json
@@ -12,6 +12,7 @@
   "env": {
     "APPRES_CMS_URL": "https://appres-q0.nav.no",
     "FASIT_ENVIRONMENT_NAME": "q0",
-    "DECORATOR_URL": "https://dekoratoren.dev.nav.no"
+    "DECORATOR_URL": "https://dekoratoren.dev.nav.no",
+    "NODE_EXTRA_CA_CERTS": "/etc/ssl/ca-bundle.pem"
   }
 }

--- a/nais/prod/prod-sbs.json
+++ b/nais/prod/prod-sbs.json
@@ -12,6 +12,7 @@
   "env": {
     "APPRES_CMS_URL": "https://appres.nav.no",
     "FASIT_ENVIRONMENT_NAME": "p",
-    "DECORATOR_URL": "https://www.nav.no/dekoratoren"
+    "DECORATOR_URL": "https://www.nav.no/dekoratoren",
+    "NODE_EXTRA_CA_CERTS": "/etc/ssl/ca-bundle.pem"
   }
 }


### PR DESCRIPTION
For å kunne hente data fra Sanity må vi bruke webproxy. Legger til ekstra certs slik at Node ikke kræsjer på https requester mot Sanity via webproxy.

Er testet i `dev-sbs` med både next og create-react-app versjonene av veiviseren og begge fungerer fint. Tar derfor sjansen på å importere certs i `prod-sbs` også.

På `dev-gcp` har vi ikke webproxy, og åpning mot Sanity gjøres via istio. Kommer en egen PR på dette.