### PR TITLE
Deployer next-app til prod

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event_name == 'repository_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     env:
-      DOCKER_IMAGE: docker.pkg.github.com/${{ github.repository }}/${{ github.event.repository.name }}
+      DOCKER_IMAGE: docker.pkg.github.com/${{ github.repository }}/${{ github.event.repository.name }}-next
     steps:
       - uses: actions/checkout@v2
       - name: Create artifact version


### PR DESCRIPTION
Deployer next-appen i stedet for cra-appen til prod. Venter med å fjerne gammel kode til etter lansering, slik at det blir lettere å rulle tilbake om noe går galt.

Vi kjører RollingUpdate på deploy, som vil si at requester mot appen kan nå både ny og gammel app i en kort periode under prodsetting. For å begrense hvor mye dette påvirker bruker bør vi ta deploy på et tidspunkt med lite trafikk

- [x] Alle tekster fra Sanity er riktige i prod-datasett
- [x] Alle lenker etc fungerer som de skal
- [x] Avklare tidspunkt for prodsetting