### PR TITLE
Legger til redirects for gamle artikler som tidligere lå i enonic

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,12 @@ Object.keys(packageJson.dependencies).forEach((key) => {
 const withTranspileModules = require("next-transpile-modules")(
     navFrontendModuler
 );
+
+const redirects = [
+    {source: "/artikkel/124876", destination: "/gi-beskjed", permanent: true},
+    {source: "/artikkel/124875", destination: "/klage", permanent: true},
+];
+
 module.exports = withTranspileModules(
     withLess({
         basePath: "/sosialhjelp",
@@ -23,6 +29,10 @@ module.exports = withTranspileModules(
             locales: ["en", "nb", "nn"],
             defaultLocale: "nb",
             localeDetection: false,
+        },
+
+        async redirects() {
+            return redirects;
         },
     })
 );


### PR DESCRIPTION
Det brukes fortsatt gamle lenker til disse artiklene et par steder på nav.no. Andre artikler fra enonic har ikke hatt treff i aksessloggene de siste månedene, så tar de ikke med her.