### PR TITLE
Skriver om build.yaml til å kun bygge nextjs-versjon av appen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,6 @@ jobs:
           restore-keys: ${{ runner.os }}-node-
       - name: Install dependencies
         run: npm ci
-      - name: Rename index_express.html to index.html
-        run: mv public/index_express.html public/index.html
       - name: Build application
         run: npm run build
       - name: Login to GitHub package registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM navikt/node-express:12.2.0-alpine
+FROM node:14-alpine
 
 ENV NODE_ENV production
 
-RUN npm install -g mustache-express@1.3.0
-
 WORKDIR /app
-COPY server.js server.js
-COPY build build/
+COPY package.json .
+COPY .next/ .next/
+COPY .env .
+# COPY .env.local . # TODO
+COPY next.config.js .
+COPY node_modules/ node_modules/
 
-CMD ["node", "./server.js"]
+EXPOSE 3000
+CMD npm run start

--- a/package.json
+++ b/package.json
@@ -86,10 +86,8 @@
     "typescript": "^4.1.5"
   },
   "scripts": {
-    "start": "craco start",
-    "build": "craco build",
-    "test": "craco test",
-    "eject": "react-scripts eject",
+    "start": "next start -p 5000",
+    "build": "next build",
     "dev": "next dev",
     "build:next": "next build",
     "start:next": "next start -p 5000"


### PR DESCRIPTION
Frem til nå har vi bygget to ulike images for veiviseren, en med nextjs og en med cra. Dette er første steget for å fase ut bygging av cra-appen. Fjerning av nextjs-spesifikke actions kommer i neste PR.