### PR TITLE
Legger til variant, som brukes av nye versjonen av alert i ds-react

### DIFF
--- a/sanity/schemas/frontpage/alert.js
+++ b/sanity/schemas/frontpage/alert.js
@@ -18,10 +18,18 @@ export default {
         },
         {
             name: "type",
-            title: "Type",
+            title: "Type (deprecated)",
             type: "string",
             options: {
                 list: ["info", "suksess", "advarsel", "feil"],
+            },
+        },
+        {
+            name: "variant",
+            title: "Variant",
+            type: "string",
+            options: {
+                list: ["success", "warning", "error", "info"],
             },
         },
         {

--- a/src/utils/sanityFetch.ts
+++ b/src/utils/sanityFetch.ts
@@ -47,6 +47,7 @@ const frontPageSpec = `
       "title": coalesce(title[$locale], title.nb),
       "slug": article->slug.current,
       type,
+      variant,
     },
   	"soknadPanel": soknadPanel->{
       "title": coalesce(title[$locale], title.nb),
@@ -153,6 +154,7 @@ export interface SanityFrontpage {
         title: string;
         slug: string;
         type: AlertStripeType;
+        variant: "error" | "warning" | "info" | "success";
     };
     soknadPanel: {
         title: string;


### PR DESCRIPTION
Legger til `variant` i Sanity, slik at vi lettere kan gå over til `@navikt/ds-react` komponentene som har andre verdier for props enn det `nav-frontend-*` har.