### PR TITLE
Legger til schema og groq for ny forside

### DIFF
--- a/sanity/schemas/frontpage/frontPage.js
+++ b/sanity/schemas/frontpage/frontPage.js
@@ -37,10 +37,42 @@ export default {
         },
         {
             name: "soknadPanel",
-            title: "Søknadpanel",
+            title: "Søknadpanel (deprecated)",
             type: "reference",
             to: {type: "linkPanel"},
             validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "applyDigitallyPanel",
+            title: "Søknadpanel",
+            type: "object",
+            fields: [
+                {
+                    name: "title",
+                    title: "Tittel",
+                    type: "localeString",
+                },
+                {
+                    name: "description",
+                    title: "Beskrivelse",
+                    type: "localeString",
+                },
+                {
+                    name: "nySoknadButtonText",
+                    title: "Ny søknad knappetekst",
+                    type: "localeString",
+                },
+                {
+                    name: "innsynButtonText",
+                    title: "Innsyn knappetekst",
+                    type: "localeString",
+                },
+                {
+                    name: "illustration",
+                    title: "Illustasjon",
+                    type: "image",
+                },
+            ],
         },
         {
             name: "linkBoxes",

--- a/sanity/schemas/frontpage/linkWithDescription.js
+++ b/sanity/schemas/frontpage/linkWithDescription.js
@@ -1,0 +1,50 @@
+import {defaultLanguage} from "../utils/lang";
+
+export default {
+    name: "linkWithDescription",
+    title: "Lenke med beskrivelse",
+    type: "object",
+    preview: {
+        select: {
+            title: `title.${defaultLanguage.id}`,
+        },
+    },
+    fields: [
+        {
+            name: "title",
+            title: "Tittel",
+            type: "localeString",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "description",
+            title: "Beskrivelse",
+            type: "localeString",
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: "icon",
+            title: "Ikon",
+            type: "image",
+        },
+        {
+            name: "article",
+            title: "Artikkel",
+            type: "reference",
+            to: [
+                {
+                    type: "article",
+                },
+                {
+                    type: "otherPossibilities",
+                },
+                {type: "applicationPage"},
+            ],
+        },
+        {
+            name: "externalLink",
+            title: "Ekstern lenke",
+            type: "url",
+        },
+    ],
+};

--- a/sanity/schemas/schema.js
+++ b/sanity/schemas/schema.js
@@ -18,6 +18,7 @@ import alert from "./frontpage/alert";
 import linkPanel from "./frontpage/linkPanel";
 import linkBoxLine from "./frontpage/linkBoxLine";
 import linkBox from "./frontpage/linkBox";
+import linkWithDescription from "./frontpage/linkWithDescription";
 import otherPossibilities from "./otherPossibilities/otherPossibilities";
 import jobblystPanel from "./otherPossibilities/jobblystPanel";
 import housingPanel from "./otherPossibilities/housingPanel";
@@ -52,6 +53,7 @@ export default createSchema({
         linkBox,
         linkBoxLine,
         linkPanel,
+        linkWithDescription,
         localeBlockContent,
         localeUrl,
         localeString,

--- a/src/utils/sanityFetch.ts
+++ b/src/utils/sanityFetch.ts
@@ -61,7 +61,29 @@ const frontPageSpec = `
            "description": coalesce(description[$locale], description.nb),
             "slug": article->slug.current,
         },
-    }
+    },
+    "applyDigitallyPanel": applyDigitallyPanel{
+        "title": coalesce(title[$locale], title.nb),
+        "description": coalesce(description[$locale], description.nb),
+        "nySoknadButtonText": coalesce(nySoknadButtonText[$locale], nySoknadButtonText.nb),
+        "innsynButtonText": coalesce(innsynButtonText[$locale], innsynButtonText.nb),
+        "illustrationUrl": illustration.asset->url,
+    },
+    "featuredArticles": featuredArticles[]{
+        "title": coalesce(title[$locale], title.nb),
+        "description": coalesce(description[$locale], description.nb),
+        "slug": article->slug.current,
+        externalLink,
+        "iconUrl": icon.asset->url,
+    },
+    "otherArticlesTitle": coalesce(otherArticlesTitle[$locale], otherArticlesTitle.nb),
+    "otherArticles": otherArticles[]{
+        "title": coalesce(title[$locale], title.nb),
+        "description": coalesce(description[$locale], description.nb),
+        "slug": article->slug.current,
+        externalLink,
+        "iconUrl": icon.asset->url,
+    },
 }
 `;
 
@@ -156,11 +178,13 @@ export interface SanityFrontpage {
         type: AlertStripeType;
         variant: "error" | "warning" | "info" | "success";
     };
+    // Deprecated - Fjernes etter at ny forside er prodsatt
     soknadPanel: {
         title: string;
         slug: string;
         iconUrl: string;
     };
+    // Deprecated - Fjernes etter at ny forside er prodsatt
     linkBoxes: [
         {
             title: string;
@@ -171,6 +195,32 @@ export interface SanityFrontpage {
                     slug: string;
                 }
             ];
+        }
+    ];
+    applyDigitallyPanel: {
+        title: string;
+        description: string;
+        nySoknadButtonText: string;
+        innsynButtonText: string;
+        illustrationUrl: string;
+    };
+    featuredArticles: [
+        {
+            title: string;
+            description: string;
+            slug?: string;
+            externalLink?: string;
+            iconUrl?: string;
+        }
+    ];
+    otherArticlesTitle: string;
+    otherArticles: [
+        {
+            title: string;
+            description: string;
+            slug?: string;
+            externalLink?: string;
+            iconUrl?: string;
         }
     ];
 }


### PR DESCRIPTION
Trekker ut schema og groq fra https://github.com/navikt/sosialhjelp-veiviser-ny/pull/261 slik at dette kan prodsettes før resten av endringene for forside, nytt grid etc flettes inn.