### PR TITLE
Reimplementerer veilederpanel mens vi venter på at panelet blir implementert i ds-react

### DIFF
--- a/components/article/ReimplementedGuidePanel.tsx
+++ b/components/article/ReimplementedGuidePanel.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import styled from "styled-components";
+
+const StyledGuidePanel = styled.div`
+    position: relative;
+    margin-top: 3.125rem;
+    padding: 4.25rem 2rem 2rem 2rem;
+
+    @media (max-width: 448px) {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+
+    border: 2px solid #99dead;
+
+    border-radius: 0.5rem;
+    display: flex;
+    align-items: center;
+
+    .navds-title {
+        text-align: center;
+    }
+`;
+
+const Icon = styled.div`
+    position: absolute;
+
+    top: -50px;
+    left: 50%;
+    margin-left: -3.125rem;
+
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+
+    background-color: #99dead;
+    height: 6.25rem;
+    width: 6.25rem;
+
+    border-radius: 50%;
+
+    overflow: hidden;
+`;
+
+export const ReimplementedGuidePanel = (props: {
+    svg: React.ReactNode;
+    children: any;
+}) => {
+    return (
+        <StyledGuidePanel>
+            <Icon>{props.svg}</Icon>
+            <div>{props.children}</div>
+        </StyledGuidePanel>
+    );
+};

--- a/pages/slik-soker-du.tsx
+++ b/pages/slik-soker-du.tsx
@@ -1,11 +1,11 @@
 import {Ingress, Title} from "@navikt/ds-react";
 import {Language} from "@navikt/nav-dekoratoren-moduler";
-import Veilederpanel from "nav-frontend-veilederpanel";
 import Head from "next/head";
 import {useRouter} from "next/router";
 import React from "react";
 import styled from "styled-components/macro";
 import {Article} from "../components/article/Article";
+import {ReimplementedGuidePanel} from "../components/article/ReimplementedGuidePanel";
 import {SokDigitalt} from "../components/article/SokDigitalt";
 import {Content} from "../components/Content";
 import {DecoratedApp} from "../components/DecoratedApp";
@@ -22,17 +22,6 @@ import {fetchNedetid, NedetidResponse} from "./api/nedetid";
 
 const StyledVeilederPanel = styled.div`
     margin: 5em 0 2em 0;
-
-    @media (max-width: 448px) {
-        .nav-veilederpanel {
-            padding-left: 1rem;
-            padding-right: 1rem;
-        }
-    }
-
-    .navds-title {
-        text-align: center;
-    }
 `;
 
 interface PageProps {
@@ -102,10 +91,7 @@ const SlikSokerDu = (props: PageProps) => {
                         <Ingress spacing>{props.page.ingress}</Ingress>
 
                         <StyledVeilederPanel>
-                            <Veilederpanel
-                                type="plakat"
-                                kompakt
-                                fargetema="suksess"
+                            <ReimplementedGuidePanel
                                 svg={
                                     <img
                                         src={
@@ -126,14 +112,11 @@ const SlikSokerDu = (props: PageProps) => {
                                         props.page.applyDigitallyPanel
                                     }
                                 />
-                            </Veilederpanel>
+                            </ReimplementedGuidePanel>
                         </StyledVeilederPanel>
 
                         <StyledVeilederPanel>
-                            <Veilederpanel
-                                type="plakat"
-                                kompakt
-                                fargetema="suksess"
+                            <ReimplementedGuidePanel
                                 svg={
                                     <img
                                         src={
@@ -149,7 +132,7 @@ const SlikSokerDu = (props: PageProps) => {
                                 <SanityBlockContent
                                     blocks={props.page.applyOfflinePanel.body}
                                 />
-                            </Veilederpanel>
+                            </ReimplementedGuidePanel>
                         </StyledVeilederPanel>
                         <SanityBlockContent blocks={props.page.body} />
                     </Article>


### PR DESCRIPTION
Veilederpanelet er det siste komponentet vi bruker fra nav-frontend-* som ikke finnes i ds-react. Dette er også den siste avhengigheten vi har til less, som er en liten blokker for oppgradering til next@11.

Det er litt usikkert om / når veilederpanelet blir implementert i ds-react. Implementerer derfor bare usecaset vi har, som er "suksess"-fargetema og typen "plakat".