### PR TITLE
Skrur av sentry i dev miljøer

### DIFF
--- a/nais/dev/dev-gcp.env
+++ b/nais/dev/dev-gcp.env
@@ -10,5 +10,5 @@ SOSIALHJELP_SOKNAD_API_URL="https://www.nav.no/sosialhjelp/soknad-api"
 NEXT_PUBLIC_SANITY_PROJECT_ID="hvfvg2j3"
 NEXT_PUBLIC_SANITY_DATASET="test"
 
-ENABLE_SENTRY="true"
+ENABLE_SENTRY="false"
 NEXT_PUBLIC_ENVIRONMENT="dev-gcp"

--- a/nais/dev/dev-sbs-intern.env
+++ b/nais/dev/dev-sbs-intern.env
@@ -10,5 +10,5 @@ SOSIALHJELP_SOKNAD_API_URL="https://www.nav.no/sosialhjelp/soknad-api"
 NEXT_PUBLIC_SANITY_PROJECT_ID="hvfvg2j3"
 NEXT_PUBLIC_SANITY_DATASET="test"
 
-ENABLE_SENTRY="true"
+ENABLE_SENTRY="false"
 NEXT_PUBLIC_ENVIRONMENT="dev-sbs-intern"

--- a/nais/dev/dev-sbs.env
+++ b/nais/dev/dev-sbs.env
@@ -10,5 +10,5 @@ SOSIALHJELP_SOKNAD_API_URL="https://www.nav.no/sosialhjelp/soknad-api"
 NEXT_PUBLIC_SANITY_PROJECT_ID="hvfvg2j3"
 NEXT_PUBLIC_SANITY_DATASET="test"
 
-ENABLE_SENTRY="true"
+ENABLE_SENTRY="false"
 NEXT_PUBLIC_ENVIRONMENT="dev-sbs"

--- a/nais/dev/labs-gcp.env
+++ b/nais/dev/labs-gcp.env
@@ -8,5 +8,5 @@ SOSIALHJELP_SOKNAD_API_URL="https://digisos.labs.nais.io/sosialhjelp/soknad-api"
 NEXT_PUBLIC_SANITY_PROJECT_ID="hvfvg2j3"
 NEXT_PUBLIC_SANITY_DATASET="test"
 
-ENABLE_SENTRY="true"
+ENABLE_SENTRY="false"
 NEXT_PUBLIC_ENVIRONMENT="labs-gcp"


### PR DESCRIPTION
Spesielt ved bygg og deploy av main branch hver natt vil det bli laget i overkant mange unødvendige releaser i Sentry for testmiljøene. Bedre å disable som default og skru på de gangene vi har behov for å teste Sentry i dev-miljø.