### PR TITLE
Hardkoder repo da det ikke sendes med på samme måte fra workflow_call

### DIFF
--- a/.github/workflows/build_and_deploy_dev.yml
+++ b/.github/workflows/build_and_deploy_dev.yml
@@ -31,7 +31,7 @@ jobs:
     name: Build and deploy to dev
     runs-on: ubuntu-latest
     env:
-      DOCKER_IMAGE: docker.pkg.github.com/${{ github.repository }}/${{ github.event.repository.name }}
+      DOCKER_IMAGE: docker.pkg.github.com/${{ github.repository }}/sosialhjelp-veiviser-ny
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_AUTH_TOKEN || secrets.sentry_auth_token }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
`repository.name` finnes tydeligvis ikke i `event`-objektet når jobben workflow trigges av `workflow_call`.